### PR TITLE
chore(@kampus/ui): Fix eslint errors

### DIFF
--- a/packages/kampus-ui/package.json
+++ b/packages/kampus-ui/package.json
@@ -15,6 +15,7 @@
     "clean": "rm -rf dist",
     "dev": "tsup src/index.tsx --format esm,cjs --watch --dts",
     "lint": "TIMING=1 eslint \"src/**/*.ts*\"",
+    "lint:fix": "TIMING=1 npm run lint -- --fix",
     "test": "jest"
   },
   "jest": {

--- a/packages/kampus-ui/src/GappedBox.tsx
+++ b/packages/kampus-ui/src/GappedBox.tsx
@@ -1,5 +1,5 @@
-import { Box } from "./layout-components/Box";
 import { styled } from "~/stitches.config";
+import { Box } from "./layout-components/Box";
 
 export const GappedBox = styled(Box, {
   display: "flex",

--- a/packages/kampus-ui/src/IconButton.tsx
+++ b/packages/kampus-ui/src/IconButton.tsx
@@ -1,5 +1,5 @@
-import { OldButton } from "./layout-components/Button";
 import { styled } from "~/stitches.config";
+import { OldButton } from "./layout-components/Button";
 
 export const IconButton = styled(OldButton, {
   display: "flex",

--- a/packages/kampus-ui/src/SmallLink.tsx
+++ b/packages/kampus-ui/src/SmallLink.tsx
@@ -1,5 +1,5 @@
-import { Link } from "./Link";
 import { styled } from "~/stitches.config";
+import { Link } from "./Link";
 
 export const SmallLink = styled(Link, {
   // color: "$gray9",


### PR DESCRIPTION
- Add `eslint:fix` script to `@kampus/ui` so we can run `npx turbo run lint:fix` and its eslint errors will be fixed.
- run `npx turbo run lint:fix` on repo.