### PR TITLE
fixed package versions for kampus-ui

### DIFF
--- a/packages/kampus-ui/package.json
+++ b/packages/kampus-ui/package.json
@@ -37,16 +37,16 @@
     "typescript": "4.7.4"
   },
   "dependencies": {
-    "@radix-ui/colors": "^0.1.8",
-    "@radix-ui/react-alert-dialog": "^1.0.0",
-    "@radix-ui/react-avatar": "^1.0.0",
-    "@radix-ui/react-dialog": "^1.0.0",
-    "@radix-ui/react-dropdown-menu": "^1.0.0",
-    "@radix-ui/react-icons": "^1.1.0",
-    "@radix-ui/react-label": "^1.0.0",
-    "@radix-ui/react-toast": "^1.1.1",
+    "@radix-ui/colors": "0.1.8",
+    "@radix-ui/react-alert-dialog": "1.0.2",
+    "@radix-ui/react-avatar": "1.0.1",
+    "@radix-ui/react-dialog": "1.0.2",
+    "@radix-ui/react-dropdown-menu": "2.0.1",
+    "@radix-ui/react-icons": "1.1.1",
+    "@radix-ui/react-label": "2.0.0",
+    "@radix-ui/react-toast": "1.1.2",
     "@remix-run/react": "1.7.5",
-    "@stitches/react": "^1.2.8",
-    "react": "^18.2.0"
+    "@stitches/react": "1.2.8",
+    "react": "18.2.0"
   }
 }


### PR DESCRIPTION
fixes #165 

I changed package versions for kampus-ui so that they use a fixed version. Since those packages are "dependant?" from eachother, version differences can and do effect functionality, which is sad... 

For more, on this issue [radix-ui](https://github.com/radix-ui/primitives), see : 

- https://github.com/radix-ui/primitives/issues/1088
- https://github.com/radix-ui/primitives/issues/1241#issuecomment-1228956377