### PR TITLE
auto reload for macos and windows

### DIFF
--- a/apps/pano/docker-compose.yaml
+++ b/apps/pano/docker-compose.yaml
@@ -7,6 +7,7 @@ services:
     entrypoint: ["turbo", "run", "docker", "--scope=@kampus-apps/pano"]
     ports:
       - "3000:3000"
+      - "8002:8002"
     environment:
       - DATABASE_URL=postgresql://pgtest:pgtest@postgres:5432/pgtest?schema=public&connect_timeout=300
       - SESSION_SECRET=sessionsecret


### PR DESCRIPTION
fixes #184 

Remix uses a websocket for development server, in our configs it uses the port 8002. So adding this port to the docker compose makes auto reload work for macOS and windows.

For windows, a WSL extension is needed and the repository files must be in WSL filesystem. In /home/username or /root.
The extension crates a vscode server in WSL and connects your VSCode into this server.

You can also click here to initiate the connexion manually, if not setup, it should setup the server automatically.
![image](https://user-images.githubusercontent.com/94180156/208272422-b55d44a7-1714-461b-b290-018b196cec97.png)

