### PR TITLE
Update readme password

### DIFF
--- a/apps/pano/README.md
+++ b/apps/pano/README.md
@@ -17,7 +17,7 @@ docker-compose up --build
 The database seed script creates a new user with some data you can use to get started:
 
 - Username: `admin`
-- Password: `123123123`
+- Password: `123123`
 
 ### Formatting
 


### PR DESCRIPTION
The readme for pano details the default admin password to be `123123123` when it was recently updated to `123123`. This changes the readme with the updated one so new contributors don't get confused.