### PR TITLE
Sort posts

### DIFF
--- a/apps/pano/src/features/comment/Comment.tsx
+++ b/apps/pano/src/features/comment/Comment.tsx
@@ -14,10 +14,10 @@ import { useFetcher, useTransition } from "@remix-run/react";
 import type { FC } from "react";
 import { useEffect, useRef, useState } from "react";
 import type { Comment } from "~/models/comment.server";
-import { useUserContext } from "../auth/user-context";
-import { CommentUpvoteButton } from "../upvote/UpvoteButton";
 import { EditCommentForm } from "./EditCommentForm";
 import { MoreOptionsDropdown } from "./MoreOptionsDropdown";
+import { useUserContext } from "../auth/user-context";
+import { CommentUpvoteButton } from "../upvote/UpvoteButton";
 type CommentProps = {
   comment: Comment;
   postID: string;
@@ -120,14 +120,14 @@ export const CommentItem: FC<CommentProps> = ({
           {(editOpen && (
             <EditCommentForm comment={comment} setEditOpen={setEditOpen} />
           )) || (
-              <Text
-                size="3"
-                lineHeight="2"
-                css={{ color: "$gray12", whiteSpace: "break-spaces" }}
-              >
-                {comment.content}
-              </Text>
-            )}
+            <Text
+              size="3"
+              lineHeight="2"
+              css={{ color: "$gray12", whiteSpace: "break-spaces" }}
+            >
+              {comment.content}
+            </Text>
+          )}
         </Box>
         <GappedBox css={{ alignItems: "center" }}>
           {user && (

--- a/apps/pano/src/features/comment/Comment.tsx
+++ b/apps/pano/src/features/comment/Comment.tsx
@@ -120,14 +120,14 @@ export const CommentItem: FC<CommentProps> = ({
           {(editOpen && (
             <EditCommentForm comment={comment} setEditOpen={setEditOpen} />
           )) || (
-            <Text
-              size="3"
-              lineHeight="2"
-              css={{ color: "$gray12", whiteSpace: "break-spaces" }}
-            >
-              {comment.content}
-            </Text>
-          )}
+              <Text
+                size="3"
+                lineHeight="2"
+                css={{ color: "$gray12", whiteSpace: "break-spaces" }}
+              >
+                {comment.content}
+              </Text>
+            )}
         </Box>
         <GappedBox css={{ alignItems: "center" }}>
           {user && (

--- a/apps/pano/src/features/post/PostItem.tsx
+++ b/apps/pano/src/features/post/PostItem.tsx
@@ -1,4 +1,11 @@
-import { Box, ExternalLink, InternalLink, GappedBox, SmallLink, Text } from "@kampus/ui";
+import {
+  Box,
+  ExternalLink,
+  GappedBox,
+  InternalLink,
+  SmallLink,
+  Text,
+} from "@kampus/ui";
 import type { SerializeFrom } from "@remix-run/node";
 import { useFetcher } from "@remix-run/react";
 import normalizeUrl from "normalize-url";

--- a/apps/pano/src/features/post/PostSortFilters.tsx
+++ b/apps/pano/src/features/post/PostSortFilters.tsx
@@ -1,0 +1,27 @@
+import { GappedBox, SmallLink } from "@kampus/ui";
+import { useLocation } from "@remix-run/react";
+
+const filters = [
+  { url: "/", text: "hepsi" },
+  { url: "/posts/active", text: "en günceller" },
+  { url: "/posts/hot", text: "en fazla yorum almışlar" },
+  { url: "/posts/liked", text: "beğenilenler" },
+];
+
+export const PostSortFilters = () => {
+  const location = useLocation();
+  const paintIfActive = (url: string) =>
+    location.pathname === url ? "$amber11" : "none";
+
+  return (
+    <GappedBox>
+      {filters.map(({ url, text }) => {
+        return (
+          <SmallLink key={url} to={url} css={{ color: paintIfActive(url) }}>
+            {text}
+          </SmallLink>
+        );
+      })}
+    </GappedBox>
+  );
+};

--- a/apps/pano/src/routes/index.tsx
+++ b/apps/pano/src/routes/index.tsx
@@ -1,8 +1,8 @@
 import { CenteredContainer } from "@kampus/ui";
-import type { LoaderFunction } from "@remix-run/node";
 import { json } from "@remix-run/node";
 import { useLoaderData } from "@remix-run/react";
 import { PostList } from "~/features/post/PostList";
+import { PostSortFilters } from "~/features/post/PostSortFilters";
 import { getAllPosts } from "~/models/post.server";
 
 export const loader = async () => {
@@ -20,7 +20,8 @@ export const Home = () => {
   }
 
   return (
-    <CenteredContainer css={{ paddingTop: 20 }}>
+    <CenteredContainer css={{ mt: 20, gap: 20 }}>
+      <PostSortFilters />
       <PostList posts={data} />
     </CenteredContainer>
   );

--- a/apps/pano/src/routes/posts/__filters.tsx
+++ b/apps/pano/src/routes/posts/__filters.tsx
@@ -1,0 +1,14 @@
+import { CenteredContainer } from "@kampus/ui";
+import { Outlet } from "@remix-run/react";
+import { PostSortFilters } from "~/features/post/PostSortFilters";
+
+export const FiltersLayout = () => {
+  return (
+    <CenteredContainer css={{ mt: 20, gap: 20 }}>
+      <PostSortFilters />
+      <Outlet />
+    </CenteredContainer>
+  );
+};
+
+export default FiltersLayout;

--- a/apps/pano/src/routes/posts/__filters/active.tsx
+++ b/apps/pano/src/routes/posts/__filters/active.tsx
@@ -1,0 +1,24 @@
+import { useLoaderData } from "@remix-run/react";
+import type { LoaderFunction } from "react-router-dom";
+import { json } from "react-router-dom";
+import { PostList } from "~/features/post/PostList";
+import type { Post } from "~/models/post.server";
+import { getActivePosts } from "~/models/post.server";
+
+type LoaderData = {
+  posts: Post[];
+};
+
+export const loader: LoaderFunction = async () => {
+  const posts = await getActivePosts();
+
+  return json<LoaderData>({ posts });
+};
+
+export const MostActivePosts = () => {
+  const { posts } = useLoaderData();
+
+  return <PostList posts={posts} />;
+};
+
+export default MostActivePosts;

--- a/apps/pano/src/routes/posts/__filters/hot.tsx
+++ b/apps/pano/src/routes/posts/__filters/hot.tsx
@@ -1,0 +1,24 @@
+import { useLoaderData } from "@remix-run/react";
+import type { LoaderFunction } from "react-router-dom";
+import { json } from "react-router-dom";
+import { PostList } from "~/features/post/PostList";
+import type { PostWithCommentCount } from "~/models/post.server";
+import { getMostCommentedPosts } from "~/models/post.server";
+
+type LoaderData = {
+  posts: PostWithCommentCount[];
+};
+
+export const loader: LoaderFunction = async () => {
+  const posts = await getMostCommentedPosts();
+
+  return json<LoaderData>({ posts });
+};
+
+export const MostCommentedPosts = () => {
+  const { posts } = useLoaderData();
+
+  return <PostList posts={posts} />;
+};
+
+export default MostCommentedPosts;

--- a/apps/pano/src/routes/posts/__filters/liked.tsx
+++ b/apps/pano/src/routes/posts/__filters/liked.tsx
@@ -1,0 +1,24 @@
+import { useLoaderData } from "@remix-run/react";
+import type { LoaderFunction } from "react-router-dom";
+import { json } from "react-router-dom";
+import { PostList } from "~/features/post/PostList";
+import type { PostWithCommentCount } from "~/models/post.server";
+import { getMostUpvotedPosts } from "~/models/post.server";
+
+type LoaderData = {
+  posts: PostWithCommentCount[];
+};
+
+export const loader: LoaderFunction = async () => {
+  const posts = await getMostUpvotedPosts();
+
+  return json<LoaderData>({ posts });
+};
+
+export const MostUpvotedPosts = () => {
+  const { posts } = useLoaderData();
+
+  return <PostList posts={posts} />;
+};
+
+export default MostUpvotedPosts;


### PR DESCRIPTION
Closes #71 

This pull request adds the following functionality:

- 3 new routes under the post route, hot, active, and liked
- A new PostSorter component
- Sorting operations

## Main concerns:
- I was going to introduce another `<Outlet />` for these routes in order to have only one `<PostSorter />` component. When I create an index route for posts and have outlet for these routes, it affects other pages such as "$slug-$id" route which is not what we want. For that reason, I had to render `<PostSorter />` at each route. Since PostSorter acts accordingly to url, there shouldn't be a state problem but I would like to hear your suggestions and come up with a better solution.
- PostSorter component's placement & styling

## Screenshots
![image](https://user-images.githubusercontent.com/8138047/208287835-f8f67027-891e-4977-a2f6-28539cd914a9.png)
![image](https://user-images.githubusercontent.com/8138047/208287733-f0b57af5-81eb-4f69-920e-0437db4a06a5.png)
![image](https://user-images.githubusercontent.com/8138047/208287801-461c9734-38e6-4244-b055-d9c4db1836ac.png)
![image](https://user-images.githubusercontent.com/8138047/208287821-212a72a0-7b10-419f-bf1d-98716fc54464.png)
