### PR TITLE
Refine data requests

### DIFF
--- a/apps/pano/src/features/post/MoreOptionsDropdown.tsx
+++ b/apps/pano/src/features/post/MoreOptionsDropdown.tsx
@@ -20,7 +20,7 @@ import { CopyToClipboard } from "react-copy-to-clipboard";
 import PostDeleteAlert from "./PostDeleteAlert";
 import { canUserEdit } from "~/features/auth/can-user-edit";
 import { useUserContext } from "~/features/auth/user-context";
-import type { Post } from "~/models/post.server";
+import type { PostWithCommentCount } from "~/models/post.server";
 import { getExternalPostURL } from "~/utils";
 
 const DotsButton = styled(IconButton, {
@@ -36,7 +36,7 @@ const Item = styled(DropdownMenuItem, {
 });
 
 interface Props {
-  post: Post;
+  post: PostWithCommentCount;
 }
 
 export const MoreOptionsDropdown: FC<Props> = ({ post }) => {

--- a/apps/pano/src/features/post/PostItem.tsx
+++ b/apps/pano/src/features/post/PostItem.tsx
@@ -2,13 +2,14 @@ import { Box, ExternalLink, GappedBox, SmallLink, Text } from "@kampus/ui";
 import { useFetcher } from "@remix-run/react";
 import normalizeUrl from "normalize-url";
 import type { FC } from "react";
+import type { PostWithCommentCount } from "~/models/post.server";
 import { useUserContext } from "../auth/user-context";
 import { UpvoteButton } from "../upvote/UpvoteButton";
 import { MoreOptionsDropdown } from "~/features/post/MoreOptionsDropdown";
 import type { Post } from "~/models/post.server";
 
 type PostItemProps = {
-  post: Post;
+  post: PostWithCommentCount;
   showContent?: boolean;
 };
 
@@ -69,7 +70,7 @@ export const PostItem: FC<PostItemProps> = ({ post, showContent = false }) => {
           >
             <Box>@{post.owner.username}</Box> |
             <SmallLink to={`/posts/${post.slug}-${post.id}`}>
-              {post.comments.length} yorum
+              {post._count.comments} yorum
             </SmallLink>
             <>
               | <MoreOptionsDropdown post={post} />

--- a/apps/pano/src/features/post/PostList.tsx
+++ b/apps/pano/src/features/post/PostList.tsx
@@ -1,10 +1,11 @@
 import { GappedBox } from "@kampus/ui";
 import type { FC } from "react";
+import type { PostWithCommentCount } from "~/models/post.server";
 import { PostItem } from "./PostItem";
 import type { Post } from "~/models/post.server";
 
 type PostListProps = {
-  posts: Post[];
+  posts: PostWithCommentCount[];
   refetch?: () => void;
 };
 

--- a/apps/pano/src/models/post.server.ts
+++ b/apps/pano/src/models/post.server.ts
@@ -5,6 +5,36 @@ import { getSitename } from "~/features/url/get-sitename";
 import type { Comment } from "~/models/comment.server";
 import { normalizeComment } from "~/models/comment.server";
 
+const selectPostWithOwner = Prisma.validator<Prisma.PostArgs>()({
+  include: {
+    owner: true,
+  },
+});
+
+export type PostWithOwner = Prisma.PostGetPayload<typeof selectPostWithOwner>;
+
+const selectPostWithUpvote = Prisma.validator<Prisma.PostArgs>()({
+  include: {
+    upvotes: true,
+  },
+});
+
+export type PostWithUpvotes = Prisma.PostGetPayload<
+  typeof selectPostWithUpvote
+>;
+
+const selectPostWithCommentCount = Prisma.validator<Prisma.PostArgs>()({
+  include: {
+    _count: {
+      select: { comments: true }
+    }
+  },
+});
+
+export type _PostWithCommentCount = Prisma.PostGetPayload<
+  typeof selectPostWithCommentCount
+>;
+
 const selectPostWithComment = Prisma.validator<Prisma.PostArgs>()({
   include: {
     comments: {
@@ -20,25 +50,9 @@ export type PostWithComments = Prisma.PostGetPayload<
   typeof selectPostWithComment
 >;
 
-const selectPostWithUpvote = Prisma.validator<Prisma.PostArgs>()({
-  include: {
-    upvotes: true,
-  },
-});
+export type Post = PostWithOwner & PostWithUpvotes & PostWithComments & _PostWithCommentCount;
 
-export type PostWithUpvotes = Prisma.PostGetPayload<
-  typeof selectPostWithUpvote
->;
-
-const selectPostWithOwner = Prisma.validator<Prisma.PostArgs>()({
-  include: {
-    owner: true,
-  },
-});
-
-export type PostWithOwner = Prisma.PostGetPayload<typeof selectPostWithOwner>;
-
-export type Post = PostWithComments & PostWithUpvotes & PostWithOwner;
+export type PostWithCommentCount = PostWithOwner & PostWithUpvotes & _PostWithCommentCount;
 
 export const getAllPosts = () => {
   return prisma.post.findMany({

--- a/apps/pano/src/models/post.server.ts
+++ b/apps/pano/src/models/post.server.ts
@@ -60,10 +60,8 @@ export const getAllPosts = () => {
     include: {
       upvotes: true,
       owner: true,
-      comments: {
-        include: {
-          owner: true,
-        },
+      _count: {
+        select: { comments: true },
       },
     },
   });
@@ -74,10 +72,8 @@ export const getPostById = (id: string) => {
     where: { id },
     include: {
       upvotes: true,
-      comments: {
-        include: {
-          owner: true,
-        },
+      _count: {
+        select: { comments: true },
       },
       owner: true,
     },
@@ -95,6 +91,9 @@ export const getPostBySlugAndId = async (slug: string, id: string) => {
           upvotes: true,
         },
       },
+      _count: {
+        select: { comments: true },
+      },
       owner: true,
     },
   });
@@ -109,10 +108,8 @@ export const getPostsBySite = (site: string) => {
     where: { site },
     include: {
       upvotes: true,
-      comments: {
-        include: {
-          owner: true,
-        },
+      _count: {
+        select: { comments: true },
       },
       owner: true,
     },
@@ -130,10 +127,8 @@ export const searchPosts = (query: string) => {
     },
     include: {
       upvotes: true,
-      comments: {
-        include: {
-          owner: true,
-        },
+      _count: {
+        select: { comments: true },
       },
       owner: true,
     },

--- a/apps/pano/src/routes/index.tsx
+++ b/apps/pano/src/routes/index.tsx
@@ -3,11 +3,11 @@ import type { LoaderFunction } from "@remix-run/node";
 import { json } from "@remix-run/node";
 import { useLoaderData } from "@remix-run/react";
 import { PostList } from "~/features/post/PostList";
-import type { Post } from "~/models/post.server";
+import type { PostWithCommentCount } from "~/models/post.server";
 import { getAllPosts } from "~/models/post.server";
 
 type LoaderData = {
-  data: Post[];
+  data: PostWithCommentCount[];
 };
 
 export const loader: LoaderFunction = async () => {

--- a/apps/pano/src/routes/posts/$id.edit.tsx
+++ b/apps/pano/src/routes/posts/$id.edit.tsx
@@ -18,13 +18,13 @@ import type { FC } from "react";
 import { useState } from "react";
 import invariant from "tiny-invariant";
 import { canUserEdit } from "~/features/auth/can-user-edit";
-import type { Post } from "~/models/post.server";
+import type { PostWithCommentCount } from "~/models/post.server";
 import { editPost, getPostById } from "~/models/post.server";
 import { requireUser } from "~/session.server";
 import { validate, validateURL } from "~/utils";
 
 type LoaderData = {
-  post: Post;
+  post: PostWithCommentCount;
 };
 
 type ActionData = {

--- a/apps/pano/src/routes/posts/$slug-$id.tsx
+++ b/apps/pano/src/routes/posts/$slug-$id.tsx
@@ -80,12 +80,12 @@ export const meta: MetaFunction = ({
   return {
     title: data.post.title,
     author: data.post.owner.username,
-    description: `${data.post.comments.length} yorum`,
+    description: `${data.post._count.comments} yorum`,
     "twitter:title": data.post.title,
-    "twitter:description": `${data.post.comments.length} yorum`,
+    "twitter:description": `${data.post._count.comments} yorum`,
     "twitter:card": "summary",
     "og:title": data.post.title,
-    "og:description": `${data.post.comments.length} yorum`,
+    "og:description": `${data.post._count.comments} yorum`,
     "og:type": "article",
   };
 };

--- a/apps/pano/src/routes/search.tsx
+++ b/apps/pano/src/routes/search.tsx
@@ -3,12 +3,12 @@ import type { LoaderFunction } from "@remix-run/node";
 import { json } from "@remix-run/node";
 import { useLoaderData } from "@remix-run/react";
 import { PostList } from "~/features/post/PostList";
-import type { Post } from "~/models/post.server";
+import type { PostWithCommentCount } from "~/models/post.server";
 import { searchPosts } from "~/models/post.server";
 
 type LoaderDataSuccess = {
   query: string;
-  data: Post[];
+  data: PostWithCommentCount[];
 };
 
 type LoaderDataError = {

--- a/apps/pano/src/routes/site/$.tsx
+++ b/apps/pano/src/routes/site/$.tsx
@@ -3,7 +3,7 @@ import type { LoaderFunction } from "@remix-run/node";
 import { json } from "@remix-run/node";
 import { useLoaderData } from "@remix-run/react";
 import { PostList } from "~/features/post/PostList";
-import type { Post } from "~/models/post.server";
+import type { PostWithCommentCount } from "~/models/post.server";
 import { getPostsBySite } from "~/models/post.server";
 
 type LoaderData = {

--- a/apps/pano/src/routes/site/$.tsx
+++ b/apps/pano/src/routes/site/$.tsx
@@ -7,7 +7,7 @@ import type { PostWithCommentCount } from "~/models/post.server";
 import { getPostsBySite } from "~/models/post.server";
 
 type LoaderData = {
-  posts: Post[];
+  posts: PostWithCommentCount[];
 };
 
 export const loader: LoaderFunction = async ({ params }) => {

--- a/apps/pano/src/utils/index.ts
+++ b/apps/pano/src/utils/index.ts
@@ -1,8 +1,7 @@
 import { useMatches } from "@remix-run/react";
 import { useMemo } from "react";
-
+import type { PostWithCommentCount } from "~/models/post.server";
 import type { Comment } from "~/models/comment.server";
-import type { Post } from "~/models/post.server";
 import type { User } from "~/models/user.server";
 
 const DEFAULT_REDIRECT = "/";
@@ -92,7 +91,7 @@ export function validatePassword(password: unknown): password is string {
   return validate(password) && password.length > 8;
 }
 
-export function getExternalPostURL(post: Post) {
+export function getExternalPostURL(post: PostWithCommentCount) {
   const location = global.location;
   const postUrl = `${location.origin}/posts/${post.slug}-${post.id}`;
   return postUrl;


### PR DESCRIPTION
PostWithCommentCount type defined. DB queries are updated with PostWithCommentCount type requirements. Post references were replaced with the PostWithCommentCount type.

getAllPosts(Posts page), getPostById(Post edit page), getPostsBySite(Posts with specified site name), searchPosts(Posts with search) queries optimized. 

Fixes #193 

<details><summary>Screenshots</summary>

### Previous Version:
Content:
![image](https://user-images.githubusercontent.com/15327343/208978063-1394073b-0fbf-4828-bfcd-c455f9b7e0a5.png)

DB response:
![image](https://user-images.githubusercontent.com/15327343/208976601-1acf186a-91a7-4c7c-9e74-dcb3ede897cb.png)

### Updated Version:
Content:
![image](https://user-images.githubusercontent.com/15327343/208978063-1394073b-0fbf-4828-bfcd-c455f9b7e0a5.png)
DB response:
![image](https://user-images.githubusercontent.com/15327343/208976816-76f7e0ab-3774-482d-95d8-a3786fef6829.png)

</details>