### PR TITLE
Title without URL

### DIFF
--- a/apps/pano/src/features/post/PostItem.tsx
+++ b/apps/pano/src/features/post/PostItem.tsx
@@ -1,4 +1,4 @@
-import { Box, ExternalLink, GappedBox, SmallLink, Text } from "@kampus/ui";
+import { Box, ExternalLink, InternalLink, GappedBox, SmallLink, Text } from "@kampus/ui";
 import { useFetcher } from "@remix-run/react";
 import normalizeUrl from "normalize-url";
 import type { FC } from "react";
@@ -39,7 +39,7 @@ export const PostItem: FC<PostItemProps> = ({ post, showContent = false }) => {
   const titleLink = post.url ? (
     <ExternalLink href={normalizeUrl(post.url)}>{post.title}</ExternalLink>
   ) : (
-    <SmallLink to={`/posts/${post.slug}-${post.id}`}>{post.title}</SmallLink>
+    <InternalLink to={`/posts/${post.slug}-${post.id}`}>{post.title}</InternalLink>
   );
 
   return (

--- a/packages/kampus-ui/src/InternalLink.tsx
+++ b/packages/kampus-ui/src/InternalLink.tsx
@@ -1,0 +1,10 @@
+import { Link as RouterLink } from "@remix-run/react";
+import { styled } from "~/stitches.config";
+
+export const InternalLink = styled(RouterLink, {
+  color: "$gray12",
+  fontWeight: "bold",
+  "&:hover": {
+    textDecoration: "none",
+  },
+});

--- a/packages/kampus-ui/src/index.tsx
+++ b/packages/kampus-ui/src/index.tsx
@@ -8,6 +8,7 @@ export * from "./Form";
 export * from "./GappedBox";
 export * from "./IconButton";
 export * from "./Input";
+export * from "./InternalLink";
 export * from "./Label";
 export * from "./Link";
 export * from "./Select";


### PR DESCRIPTION
An InternalLink component has been created and added to the Kampus/UI package. The package's index file has been updated to include the new component.

The InternalLink component is similar to the ExternalLink component, but it only redirects users to locations within the same website or application.

Fixes #190 

<details><summary>Screenshots</summary>

### Previous Version:

![image](https://user-images.githubusercontent.com/15327343/209654830-c0c1721e-8c40-475f-9860-25b9c2262730.png)

### Updated Version:

![image](https://user-images.githubusercontent.com/15327343/209654943-4516f22c-40a1-497c-a696-fa9582b79596.png)


</details>