### PR TITLE
feat(@kampus-apps/pano): add remix-auth and remix-auth-form strategy

### DIFF
--- a/apps/pano/app/features/authenticator/KampusAuthenticator.ts
+++ b/apps/pano/app/features/authenticator/KampusAuthenticator.ts
@@ -1,0 +1,62 @@
+import type { Authenticator, Strategy } from "remix-auth";
+import { AuthorizationError } from "remix-auth";
+
+export { AuthorizationError };
+
+type StrategyMap<TKey extends string, TUser = unknown> = Record<
+  TKey,
+  Strategy<TUser, never>
+>;
+
+interface Props<
+  TStrategies extends StrategyMap<TKey, TUser>,
+  TKey extends string = string,
+  TUser = unknown
+> {
+  readonly strategies: TStrategies;
+  readonly authenticator: Authenticator<TUser>;
+}
+
+export class KampusAuthenticator<
+  TStrategies extends StrategyMap<TKey, TUser>,
+  TKey extends string = string,
+  TUser = any
+> {
+  readonly strategies: TStrategies;
+  readonly authenticator: Authenticator<TUser>;
+
+  constructor({ strategies, authenticator }: Props<TStrategies, TKey, TUser>) {
+    this.strategies = strategies;
+    this.authenticator = authenticator;
+
+    Object.entries<Strategy<TUser, never>>(this.strategies).forEach(
+      ([name, strategy]) => {
+        this.authenticator.use(strategy, name);
+      }
+    );
+  }
+
+  public authenticate(name: TKey, request: Request, options: any) {
+    return this.authenticator.authenticate(name, request, options);
+  }
+
+  public isAuthenticated(request: Request, options?: RedirectOptions) {
+    return this.authenticator.isAuthenticated(request, options as any);
+  }
+
+  public logout(request: Request, options: { redirectTo: string }) {
+    return this.authenticator.logout(request, options);
+  }
+}
+
+type RedirectOptions =
+  | {
+      successRedirect: string;
+    }
+  | {
+      failureRedirect: string;
+    }
+  | {
+      successRedirect: string;
+      failureRedirect: string;
+    };

--- a/apps/pano/app/features/authenticator/index.ts
+++ b/apps/pano/app/features/authenticator/index.ts
@@ -1,0 +1,14 @@
+import { Authenticator } from "remix-auth";
+import type { User } from "~/models/user.server";
+import { sessionStorage } from "~/session.server";
+import { KampusAuthenticator } from "./KampusAuthenticator";
+import { strategies } from "./strategies";
+
+export const authenticator = new KampusAuthenticator<
+  typeof strategies,
+  keyof typeof strategies,
+  User
+>({
+  strategies,
+  authenticator: new Authenticator(sessionStorage),
+});

--- a/apps/pano/app/features/authenticator/strategies.ts
+++ b/apps/pano/app/features/authenticator/strategies.ts
@@ -1,0 +1,26 @@
+import { AuthorizationError } from "remix-auth";
+import { FormStrategy } from "remix-auth-form";
+import { verifyLogin } from "~/models/user.server";
+
+export const strategies = {
+  "user-pass": new FormStrategy(async ({ form }) => {
+    const username = form.get("username");
+    const password = form.get("password");
+    // const redirectTo = safeRedirect(form.get("redirectTo"), "/");
+    //
+    if (typeof username !== "string" || username.length < 3) {
+      throw new AuthorizationError("Kullanıcı adı en az 3 karakter olmalıdır.");
+    }
+
+    if (typeof password !== "string" || password.length < 6) {
+      throw new AuthorizationError("Şifre en az 6 karakter olmalıdır.");
+    }
+
+    const user = await verifyLogin(username, password);
+    if (!user) {
+      throw new AuthorizationError("Kullanıcı adı veya şifre hatalı.");
+    }
+
+    return user;
+  }),
+};

--- a/apps/pano/app/models/user.server.ts
+++ b/apps/pano/app/models/user.server.ts
@@ -1,7 +1,13 @@
-import type { Password, User, UserPreference } from "@prisma/client";
+import type {
+  Password,
+  User as PrismaUser,
+  UserPreference,
+} from "@prisma/client";
 import { Theme } from "@prisma/client";
 import bcrypt from "bcryptjs";
 import { prisma } from "~/db.server";
+
+export type User = PrismaUser;
 
 export async function getUserById(id: User["id"]) {
   return prisma.user.findUnique({ where: { id } });

--- a/apps/pano/app/session.server.ts
+++ b/apps/pano/app/session.server.ts
@@ -1,9 +1,9 @@
 import { createCookieSessionStorage, redirect } from "@remix-run/node";
 import invariant from "tiny-invariant";
-
-import { env } from "./utils/env.server";
-import { getTheme, User } from "~/models/user.server";
+import type { User } from "~/models/user.server";
+import { getTheme } from "~/models/user.server";
 import { getUserById } from "~/models/user.server";
+import { env } from "./utils/env.server";
 
 invariant(env.SESSION_SECRET, "SESSION_SECRET must be set");
 

--- a/apps/pano/package.json
+++ b/apps/pano/package.json
@@ -39,6 +39,8 @@
     "react": "18.2.0",
     "react-copy-to-clipboard": "5.1.0",
     "react-dom": "18.2.0",
+    "remix-auth": "3.4.0",
+    "remix-auth-form": "1.3.0",
     "slugify": "1.6.5",
     "tiny-invariant": "1.3.1",
     "zod": "3.20.6"

--- a/package-lock.json
+++ b/package-lock.json
@@ -32,6 +32,8 @@
         "react": "18.2.0",
         "react-copy-to-clipboard": "5.1.0",
         "react-dom": "18.2.0",
+        "remix-auth": "3.4.0",
+        "remix-auth-form": "1.3.0",
         "slugify": "1.6.5",
         "tiny-invariant": "1.3.1",
         "zod": "3.20.6"
@@ -13942,6 +13944,27 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/remix-auth": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/remix-auth/-/remix-auth-3.4.0.tgz",
+      "integrity": "sha512-VRliJo9VRAS4sSYgMjYbi7rYRixPWU2Tb8PFZb06OIj0nONK/1KRzHf2+Y6VGZeIacepLVgan6g2IUJjayE2rQ==",
+      "dependencies": {
+        "uuid": "^8.3.2"
+      },
+      "peerDependencies": {
+        "@remix-run/react": "^1.0.0",
+        "@remix-run/server-runtime": "^1.0.0"
+      }
+    },
+    "node_modules/remix-auth-form": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/remix-auth-form/-/remix-auth-form-1.3.0.tgz",
+      "integrity": "sha512-m+pwFJM61+qGPIvROHmN7LANJMbpL2QgYen/wY8wnJfwwannWt2+7zEoGWF7NbxMnoxCib75EGlPZpyyvwtBXQ==",
+      "peerDependencies": {
+        "@remix-run/server-runtime": "^1.0.0",
+        "remix-auth": "^3.4.0"
+      }
+    },
     "node_modules/remove-trailing-separator": {
       "version": "1.1.0",
       "license": "ISC"
@@ -16678,7 +16701,6 @@
     "node_modules/uuid": {
       "version": "8.3.2",
       "license": "MIT",
-      "optional": true,
       "bin": {
         "uuid": "dist/bin/uuid"
       }


### PR DESCRIPTION
We introduce our own `KampusAuthenticator` to make sure `authenticator.authenticate` call is type safe, and autocompletes with the strategies we register when we are creating an instance.

Fixes #241 