### PR TITLE
Replace loader action function

### DIFF
--- a/apps/pano/app/features/post/PostItem.tsx
+++ b/apps/pano/app/features/post/PostItem.tsx
@@ -6,7 +6,6 @@ import {
   SmallLink,
   Text,
 } from "@kampus/ui";
-import type { SerializeFrom } from "@remix-run/node";
 import { useFetcher } from "@remix-run/react";
 import normalizeUrl from "normalize-url";
 import type { FC } from "react";
@@ -16,7 +15,7 @@ import { useUserContext } from "../auth/user-context";
 import { UpvoteButton } from "../upvote/UpvoteButton";
 
 type PostItemProps = {
-  post: SerializeFrom<PostWithCommentCount>;
+  post: PostWithCommentCount;
   showContent?: boolean;
 };
 

--- a/apps/pano/app/features/post/PostList.tsx
+++ b/apps/pano/app/features/post/PostList.tsx
@@ -1,11 +1,10 @@
 import { GappedBox } from "@kampus/ui";
-import type { SerializeFrom } from "@remix-run/node";
 import type { FC } from "react";
 import type { PostWithCommentCount } from "~/models/post.server";
 import { PostItem } from "./PostItem";
 
 type PostListProps = {
-  posts: SerializeFrom<PostWithCommentCount[]>;
+  posts: PostWithCommentCount[];
   refetch?: () => void;
 };
 

--- a/apps/pano/app/root.tsx
+++ b/apps/pano/app/root.tsx
@@ -112,7 +112,9 @@ const Document = () => {
 };
 
 export default function App() {
-  const { user } = useLoaderData<typeof loader>();
+  const { user } = useLoaderData() as {
+    user: Awaited<ReturnType<typeof getUser>>;
+  };
 
   return (
     <ThemeProvider>

--- a/apps/pano/app/routes/__auth/logout.tsx
+++ b/apps/pano/app/routes/__auth/logout.tsx
@@ -1,6 +1,5 @@
-import type { LoaderFunction } from "@remix-run/node";
 import { redirect } from "@remix-run/node";
 
-export const loader: LoaderFunction = async () => {
+export const loader = async () => {
   return redirect("/");
 };

--- a/apps/pano/app/routes/api/auth/login.ts
+++ b/apps/pano/app/routes/api/auth/login.ts
@@ -1,4 +1,4 @@
-import type { ActionFunction } from "@remix-run/node";
+import type { ActionArgs } from "@remix-run/node";
 import { json } from "@remix-run/node";
 import { verifyLogin } from "~/models/user.server";
 import { createUserSession } from "~/session.server";
@@ -11,7 +11,7 @@ export interface ActionData {
   };
 }
 
-export const action: ActionFunction = async ({ request }) => {
+export const action = async ({ request }: ActionArgs) => {
   const formData = await request.formData();
   const username = formData.get("username");
   const password = formData.get("password");

--- a/apps/pano/app/routes/api/auth/logout.ts
+++ b/apps/pano/app/routes/api/auth/logout.ts
@@ -1,8 +1,8 @@
-import type { ActionFunction } from "@remix-run/node";
+import type { ActionArgs } from "@remix-run/node";
 import { redirect } from "@remix-run/node";
 import { logout } from "~/session.server";
 
-export const action: ActionFunction = async ({ request }) => {
+export const action = async ({ request }: ActionArgs) => {
   return redirect("/", {
     headers: {
       "Set-Cookie": await logout(request),

--- a/apps/pano/app/routes/api/auth/register.ts
+++ b/apps/pano/app/routes/api/auth/register.ts
@@ -1,4 +1,4 @@
-import type { ActionFunction } from "@remix-run/node";
+import type { ActionArgs } from "@remix-run/node";
 import { json } from "@remix-run/node";
 import { createUser, getUserByEmail } from "~/models/user.server";
 import {
@@ -17,7 +17,7 @@ export interface ActionData {
   };
 }
 
-export const action: ActionFunction = async ({ request }) => {
+export const action = async ({ request }: ActionArgs) => {
   const formData = await request.formData();
   // const redirectTo = safeRedirect(formData.get("redirectTo"), "/");
   const username = formData.get("username");

--- a/apps/pano/app/routes/api/parse-meta.ts
+++ b/apps/pano/app/routes/api/parse-meta.ts
@@ -1,9 +1,9 @@
-import type { ActionFunction } from "@remix-run/node";
+import type { ActionArgs } from "@remix-run/node";
 import { json } from "@remix-run/node";
 import { parser } from "html-metadata-parser";
 import invariant from "tiny-invariant";
 
-export const action: ActionFunction = async ({ request }) => {
+export const action = async ({ request }: ActionArgs) => {
   const formData = await request.formData();
   const url = formData.get("url");
 

--- a/apps/pano/app/routes/change-theme.tsx
+++ b/apps/pano/app/routes/change-theme.tsx
@@ -1,13 +1,15 @@
-import { ActionFunction } from "@remix-run/node";
-import { useUserContext } from "~/features/auth/user-context";
+import { Theme } from "@prisma/client";
+import { ActionArgs } from "@remix-run/node";
 import { updateTheme } from "~/models/user.server";
 import { requireUser } from "~/session.server";
 
-export const action: ActionFunction = async ({ request }) => {
+export const action = async ({ request }: ActionArgs) => {
   const formData = await request.formData();
   const user = await requireUser(request);
 
-  const theme = formData.get("theme");
+  const theme = formData.get("theme") as Theme;
+
+  // TODO: as theme or if not theme, return error?
 
   try {
     await updateTheme(user, theme);

--- a/apps/pano/app/routes/change-theme.tsx
+++ b/apps/pano/app/routes/change-theme.tsx
@@ -9,8 +9,6 @@ export const action = async ({ request }: ActionArgs) => {
 
   const theme = formData.get("theme") as Theme;
 
-  // TODO: as theme or if not theme, return error?
-
   try {
     await updateTheme(user, theme);
     return {

--- a/apps/pano/app/routes/commentEdit.tsx
+++ b/apps/pano/app/routes/commentEdit.tsx
@@ -1,8 +1,8 @@
-import type { ActionFunction } from "@remix-run/node";
+import type { ActionArgs } from "@remix-run/node";
 import invariant from "tiny-invariant";
 import { editComment } from "~/models/comment.server";
 
-export const action: ActionFunction = async ({ request }) => {
+export const action = async ({ request }: ActionArgs) => {
   const formData = await request.formData();
   const jsonData = formData.get("json") as string | null;
 

--- a/apps/pano/app/routes/commentUpvote.tsx
+++ b/apps/pano/app/routes/commentUpvote.tsx
@@ -1,8 +1,8 @@
-import type { ActionFunction } from "@remix-run/node";
+import { ActionArgs } from "@remix-run/node";
 import invariant from "tiny-invariant";
 import { createUpvote, deleteUpvote } from "~/models/comment.server";
 
-export const action: ActionFunction = async ({ request }) => {
+export const action = async ({ request }: ActionArgs) => {
   const formData = await request.formData();
   const jsonData = formData.get("json") as string | null;
 

--- a/apps/pano/app/routes/delete-comment.ts
+++ b/apps/pano/app/routes/delete-comment.ts
@@ -1,9 +1,9 @@
-import type { ActionFunction } from "@remix-run/node";
+import type { ActionArgs } from "@remix-run/node";
 import { json } from "@remix-run/node";
 import invariant from "tiny-invariant";
 import { deleteComment } from "~/models/comment.server";
 
-export const action: ActionFunction = async ({ request }) => {
+export const action = async ({ request }: ActionArgs) => {
   const formData = await request.formData();
   const jsonData = formData.get("json");
 

--- a/apps/pano/app/routes/delete-post.ts
+++ b/apps/pano/app/routes/delete-post.ts
@@ -1,9 +1,9 @@
-import type { ActionFunction } from "@remix-run/node";
+import type { ActionArgs } from "@remix-run/node";
 import { json, redirect } from "@remix-run/node";
 import invariant from "tiny-invariant";
 import { deletePost } from "~/models/post.server";
 
-export const action: ActionFunction = async ({ request }) => {
+export const action = async ({ request }: ActionArgs) => {
   const formData = await request.formData();
   const jsonData = formData.get("json");
 

--- a/apps/pano/app/routes/posts/$id.edit.tsx
+++ b/apps/pano/app/routes/posts/$id.edit.tsx
@@ -9,7 +9,7 @@ import {
   Textarea,
   ValidationMessage,
 } from "@kampus/ui";
-import type { ActionFunction, LoaderFunction } from "@remix-run/node";
+import type { ActionArgs, LoaderArgs } from "@remix-run/node";
 import { redirect } from "@remix-run/node";
 import { json } from "@remix-run/node";
 import { useActionData, useLoaderData, useTransition } from "@remix-run/react";
@@ -33,7 +33,7 @@ type ActionData = {
   };
 };
 
-export const loader: LoaderFunction = async ({ request, params }) => {
+export const loader = async ({ request, params }: LoaderArgs) => {
   if (!params.id) return null;
 
   const user = await requireUser(request);
@@ -46,7 +46,7 @@ export const loader: LoaderFunction = async ({ request, params }) => {
   return json<LoaderData>({ post });
 };
 
-export const action: ActionFunction = async ({ request, params }) => {
+export const action = async ({ request, params }: ActionArgs) => {
   invariant(params.id, "Post id is required");
 
   const formData = await request.formData();
@@ -99,15 +99,22 @@ export const action: ActionFunction = async ({ request, params }) => {
 
 export const EditPost: FC = () => {
   const { post } = useLoaderData<LoaderData>();
+
   const transition = useTransition();
   const data = useActionData<ActionData>();
   const error = data?.error;
+
   return (
     <CenteredContainer>
       <Form method="post">
         <GappedBox css={{ flexDirection: "column", marginTop: 10 }}>
           <Label htmlFor="url">URL</Label>
-          <Input id="url" name="url" size="2" defaultValue={post.url} />
+          <Input
+            id="url"
+            name="url"
+            size="2"
+            defaultValue={post.url as string}
+          />
           <Label htmlFor="title">Başlık</Label>
           <Input id="title" name="title" size="2" defaultValue={post.title} />
           <Label htmlFor="content">İçerik</Label>
@@ -115,7 +122,7 @@ export const EditPost: FC = () => {
             css={{ width: "auto", cursor: "text" }}
             name="content"
             rows={4}
-            defaultValue={post.content}
+            defaultValue={post.content as string}
           />
           <Box>
             <Button size="2" type="submit" variant="green">

--- a/apps/pano/app/routes/posts/$slug.$id.tsx
+++ b/apps/pano/app/routes/posts/$slug.$id.tsx
@@ -10,11 +10,7 @@ import {
   ValidationMessage,
 } from "@kampus/ui";
 import { PlusIcon } from "@radix-ui/react-icons";
-import type {
-  ActionFunction,
-  LoaderFunction,
-  MetaFunction,
-} from "@remix-run/node";
+import type { ActionArgs, LoaderArgs, MetaFunction } from "@remix-run/node";
 import { json } from "@remix-run/node";
 import {
   useActionData,
@@ -59,7 +55,7 @@ const toVisualTree = (comments: Comment[]) => {
   return tree;
 };
 
-export const loader: LoaderFunction = async ({ params }) => {
+export const loader = async ({ params }: LoaderArgs) => {
   if (typeof params.slug !== "string" || typeof params.id !== "string") {
     return json({ data: null }, { status: 404 });
   }
@@ -119,7 +115,7 @@ const errorMessage = (
   );
 };
 
-export const action: ActionFunction = async ({ request, params }) => {
+export const action = async ({ request, params }: ActionArgs) => {
   const formData = await request.formData();
   const content = formData.get("content")?.toString();
   const commentID = formData.get("commentID")?.toString();
@@ -150,7 +146,7 @@ export const action: ActionFunction = async ({ request, params }) => {
 
 const SinglePost = () => {
   const user = useUserContext();
-  const { post } = useLoaderData<LoaderData>();
+  const { post } = useLoaderData() as unknown as LoaderData;
   const location = useLocation();
   const expanded = !!location.hash;
 

--- a/apps/pano/app/routes/posts/__filters/active.tsx
+++ b/apps/pano/app/routes/posts/__filters/active.tsx
@@ -1,5 +1,4 @@
 import { useLoaderData } from "@remix-run/react";
-import type { LoaderFunction } from "react-router-dom";
 import { json } from "react-router-dom";
 import { PostList } from "~/features/post/PostList";
 import type { Post } from "~/models/post.server";
@@ -9,7 +8,7 @@ type LoaderData = {
   posts: Post[];
 };
 
-export const loader: LoaderFunction = async () => {
+export const loader = async () => {
   const posts = await getActivePosts();
 
   return json<LoaderData>({ posts });

--- a/apps/pano/app/routes/posts/__filters/hot.tsx
+++ b/apps/pano/app/routes/posts/__filters/hot.tsx
@@ -1,5 +1,4 @@
 import { useLoaderData } from "@remix-run/react";
-import type { LoaderFunction } from "react-router-dom";
 import { json } from "react-router-dom";
 import { PostList } from "~/features/post/PostList";
 import type { PostWithCommentCount } from "~/models/post.server";
@@ -9,7 +8,7 @@ type LoaderData = {
   posts: PostWithCommentCount[];
 };
 
-export const loader: LoaderFunction = async () => {
+export const loader = async () => {
   const posts = await getMostCommentedPosts();
 
   return json<LoaderData>({ posts });

--- a/apps/pano/app/routes/posts/__filters/liked.tsx
+++ b/apps/pano/app/routes/posts/__filters/liked.tsx
@@ -1,5 +1,4 @@
 import { useLoaderData } from "@remix-run/react";
-import type { LoaderFunction } from "react-router-dom";
 import { json } from "react-router-dom";
 import { PostList } from "~/features/post/PostList";
 import type { PostWithCommentCount } from "~/models/post.server";
@@ -9,7 +8,7 @@ type LoaderData = {
   posts: PostWithCommentCount[];
 };
 
-export const loader: LoaderFunction = async () => {
+export const loader = async () => {
   const posts = await getMostUpvotedPosts();
 
   return json<LoaderData>({ posts });

--- a/apps/pano/app/routes/search.tsx
+++ b/apps/pano/app/routes/search.tsx
@@ -1,6 +1,5 @@
 import { CenteredContainer, Text } from "@kampus/ui";
-import type { LoaderFunction } from "@remix-run/node";
-import { json } from "@remix-run/node";
+import { json, LoaderArgs } from "@remix-run/node";
 import { useLoaderData } from "@remix-run/react";
 import { PostList } from "~/features/post/PostList";
 import type { PostWithCommentCount } from "~/models/post.server";
@@ -22,7 +21,7 @@ const isError = (data: LoaderData): data is LoaderDataError => {
   return (data as LoaderDataError).error !== undefined;
 };
 
-export const loader: LoaderFunction = async ({ request }) => {
+export const loader = async ({ request }: LoaderArgs) => {
   const url = new URL(request.url);
   const searchQuery = url.searchParams.get("q");
   if (!searchQuery) {
@@ -33,15 +32,15 @@ export const loader: LoaderFunction = async ({ request }) => {
     const posts = await searchPosts(searchQuery);
     return json({ data: posts, query: searchQuery });
   } catch (e) {
-    return {
+    return json<LoaderDataError>({
       status: 500,
-      error: e,
-    };
+      error: e as string,
+    });
   }
 };
 
 export const Search = () => {
-  const loaderData = useLoaderData<LoaderData>();
+  const loaderData = useLoaderData() as LoaderData;
 
   if (isError(loaderData)) {
     return (

--- a/apps/pano/app/routes/send.tsx
+++ b/apps/pano/app/routes/send.tsx
@@ -8,7 +8,7 @@ import {
   Textarea,
   ValidationMessage,
 } from "@kampus/ui";
-import type { ActionFunction } from "@remix-run/node";
+import type { ActionArgs } from "@remix-run/node";
 import { json, redirect } from "@remix-run/node";
 import { useFetcher, useTransition } from "@remix-run/react";
 import normalizeUrl from "normalize-url";
@@ -22,7 +22,7 @@ type ActionData = {
   };
 };
 
-export const action: ActionFunction = async ({ request }) => {
+export const action = async ({ request }: ActionArgs) => {
   const formData = await request.formData();
   const title = formData.get("title")?.toString();
   const content = formData.get("content")?.toString();
@@ -77,9 +77,7 @@ const Send = () => {
       formData.set("url", url);
       fetcher.submit(formData, { method: "post", action: "/api/parse-meta" });
     }
-  }
-
-
+  };
 
   return (
     <CenteredContainer css={{ paddingTop: 20 }}>

--- a/apps/pano/app/routes/settings.tsx
+++ b/apps/pano/app/routes/settings.tsx
@@ -9,7 +9,7 @@ import {
   Text,
   ValidationMessage,
 } from "@kampus/ui";
-import type { ActionFunction, LoaderFunction } from "@remix-run/node";
+import type { ActionArgs,  LoaderArgs } from "@remix-run/node";
 import { json } from "@remix-run/node";
 import { useActionData } from "@remix-run/react";
 import type { FC } from "react";
@@ -40,7 +40,7 @@ const SchemaWithoutPasswords = SettingsSchema.omit({
 type SettingsFields = z.infer<typeof SettingsSchema>;
 type SettingsFieldsErrors = inferSafeParseErrors<typeof SettingsSchema>;
 
-export const loader: LoaderFunction = async ({ request }) => {
+export const loader = async ({ request }: LoaderArgs) => {
   await requireUser(request);
   return true;
 };
@@ -52,7 +52,7 @@ type ActionData = {
 };
 const badRequest = (data: ActionData) => json(data, { status: 400 });
 
-export const action: ActionFunction = async ({ request }) => {
+export const action = async ({ request }: ActionArgs) => {
   const user = await requireUser(request);
   const formData = await request.formData();
   const fields = Object.fromEntries(formData.entries()) as SettingsFields;

--- a/apps/pano/app/routes/site/$.tsx
+++ b/apps/pano/app/routes/site/$.tsx
@@ -1,5 +1,5 @@
 import { CenteredContainer } from "@kampus/ui";
-import type { LoaderFunction } from "@remix-run/node";
+import type { LoaderArgs } from "@remix-run/node";
 import { json } from "@remix-run/node";
 import { useLoaderData } from "@remix-run/react";
 import { PostList } from "~/features/post/PostList";
@@ -10,7 +10,7 @@ type LoaderData = {
   posts: PostWithCommentCount[];
 };
 
-export const loader: LoaderFunction = async ({ params }) => {
+export const loader = async ({ params }: LoaderArgs) => {
   const sitename = params["*"];
 
   if (!sitename) return json(null, { status: 400 });

--- a/apps/pano/app/routes/site/$.tsx
+++ b/apps/pano/app/routes/site/$.tsx
@@ -25,7 +25,7 @@ export const loader = async ({ params }: LoaderArgs) => {
 };
 
 export const Search = () => {
-  const { posts } = useLoaderData<LoaderData>();
+  const { posts } = useLoaderData() as unknown as LoaderData;
   const sortedPosts = [...posts].sort((a, b) =>
     a.createdAt < b.createdAt ? 1 : -1
   );

--- a/apps/pano/app/routes/upvote.tsx
+++ b/apps/pano/app/routes/upvote.tsx
@@ -1,8 +1,8 @@
-import type { ActionFunction } from "@remix-run/node";
+import { ActionArgs } from "@remix-run/node";
 import invariant from "tiny-invariant";
 import { createUpvote, deleteUpvote } from "~/models/post.server";
 
-export const action: ActionFunction = async ({ request }) => {
+export const action = async ({ request }: ActionArgs) => {
   const formData = await request.formData();
   const jsonData = formData.get("json") as string | null;
 


### PR DESCRIPTION
#256 

### Things to discuss

Apart from replacing action/loader function types with action/loader args, I've also managed to _get rid of type errors_ that are occurring due to the different types coming from useLoaderData itself, such as `<SerializeObject>` or `<UndefinedToOptional>`

I don't know if we strictly want `useLoaderData<typeof loader> `thing but it causes a lot of headaches, we should whether do it as `useLoaderData() as LoaderData` or something like this 
```
useLoaderData() as {
    user: Awaited<ReturnType<typeof getUser>>;
  };
```

what do you think?