### PR TITLE
refactor: type and import problems

### DIFF
--- a/apps/pano/app/features/auth/user-context.tsx
+++ b/apps/pano/app/features/auth/user-context.tsx
@@ -2,14 +2,6 @@ import type { User } from "@prisma/client";
 import type { FC, PropsWithChildren } from "react";
 import { createContext, useContext } from "react";
 
-// we are removing this
-export interface AuthUser {
-  username: string;
-  attributes: {
-    email: string;
-  };
-}
-
 export const UserContext = createContext<User | null>(null);
 
 export const useUserContext = () => useContext(UserContext);

--- a/apps/pano/app/features/authenticator/index.ts
+++ b/apps/pano/app/features/authenticator/index.ts
@@ -1,8 +1,8 @@
 import { Authenticator } from "remix-auth";
-import type { User } from "~/models/user.server";
-import { sessionStorage } from "~/session.server";
 import { KampusAuthenticator } from "./KampusAuthenticator";
 import { strategies } from "./strategies";
+import type { User } from "~/models/user.server";
+import { sessionStorage } from "~/session.server";
 
 export const authenticator = new KampusAuthenticator<
   typeof strategies,

--- a/apps/pano/app/features/comment/Comment.tsx
+++ b/apps/pano/app/features/comment/Comment.tsx
@@ -13,11 +13,11 @@ import {
 import { useFetcher, useTransition } from "@remix-run/react";
 import type { FC } from "react";
 import { useEffect, useRef, useState } from "react";
-import type { Comment } from "~/models/comment.server";
 import { EditCommentForm } from "./EditCommentForm";
 import { MoreOptionsDropdown } from "./MoreOptionsDropdown";
 import { useUserContext } from "../auth/user-context";
 import { CommentUpvoteButton } from "../upvote/UpvoteButton";
+import type { Comment } from "~/models/comment.server";
 type CommentProps = {
   comment: Comment;
   postID: string;

--- a/apps/pano/app/features/comment/MoreOptionsDropdown.tsx
+++ b/apps/pano/app/features/comment/MoreOptionsDropdown.tsx
@@ -16,11 +16,11 @@ import { DotsHorizontalIcon } from "@radix-ui/react-icons";
 import type { FC } from "react";
 import { useEffect, useState } from "react";
 import { CopyToClipboard } from "react-copy-to-clipboard";
+import CommentDeleteAlert from "./CommentDeleteAlert";
 import { canUserEdit } from "~/features/auth/can-user-edit";
 import { useUserContext } from "~/features/auth/user-context";
 import type { Comment } from "~/models/comment.server";
 import { getExternalCommentURL } from "~/utils";
-import CommentDeleteAlert from "./CommentDeleteAlert";
 
 const DotsButton = styled(IconButton, {
   borderRadius: 5,

--- a/apps/pano/app/features/post/MoreOptionsDropdown.tsx
+++ b/apps/pano/app/features/post/MoreOptionsDropdown.tsx
@@ -17,11 +17,11 @@ import { useNavigate } from "@remix-run/react";
 import type { FC } from "react";
 import { useEffect, useState } from "react";
 import { CopyToClipboard } from "react-copy-to-clipboard";
+import PostDeleteAlert from "./PostDeleteAlert";
 import { canUserEdit } from "~/features/auth/can-user-edit";
 import { useUserContext } from "~/features/auth/user-context";
 import type { PostWithCommentCount } from "~/models/post.server";
 import { getExternalPostURL } from "~/utils";
-import PostDeleteAlert from "./PostDeleteAlert";
 
 const DotsButton = styled(IconButton, {
   borderRadius: 5,
@@ -69,6 +69,7 @@ export const MoreOptionsDropdown: FC<Props> = ({ post }) => {
     ownerItems.push(<DropdownMenuSeparator key="separator" />);
   }
 
+  // FIXME: below appears to be redundant, is it?
   const menuItems = [...ownerItems];
 
   return (

--- a/apps/pano/app/features/post/PostItem.tsx
+++ b/apps/pano/app/features/post/PostItem.tsx
@@ -10,10 +10,10 @@ import type { SerializeFrom } from "@remix-run/node";
 import { useFetcher } from "@remix-run/react";
 import normalizeUrl from "normalize-url";
 import type { FC } from "react";
+import { useUserContext } from "../auth/user-context";
+import { UpvoteButton } from '../upvote/UpvoteButton';
 import { MoreOptionsDropdown } from "~/features/post/MoreOptionsDropdown";
 import type { PostWithCommentCount } from "~/models/post.server";
-import { useUserContext } from "../auth/user-context";
-import { UpvoteButton } from "../upvote/UpvoteButton";
 import { getPostLink, getSitePostsLink } from "~/utils";
 
 type PostItemProps = {

--- a/apps/pano/app/features/post/PostList.tsx
+++ b/apps/pano/app/features/post/PostList.tsx
@@ -1,8 +1,8 @@
 import { GappedBox } from "@kampus/ui";
 import type { SerializeFrom } from "@remix-run/node";
 import type { FC } from "react";
-import type { PostWithCommentCount } from "~/models/post.server";
 import { PostItem } from "./PostItem";
+import type { PostWithCommentCount } from "~/models/post.server";
 
 type PostListProps = {
   posts: SerializeFrom<PostWithCommentCount[]>;

--- a/apps/pano/app/features/topnav/Topnav.tsx
+++ b/apps/pano/app/features/topnav/Topnav.tsx
@@ -10,9 +10,9 @@ import {
 import { PlusIcon } from "@radix-ui/react-icons";
 import { useFetcher } from "@remix-run/react";
 import type { FC } from "react";
+import { SearchInput } from "./SearchInput";
 import { useUserContext } from "~/features/auth/user-context";
 import { UserDropdown } from "~/features/user-dropdown/UserDropdown";
-import { SearchInput } from "./SearchInput";
 
 export const Topnav: FC = () => {
   const user = useUserContext();

--- a/apps/pano/app/models/user.server.ts
+++ b/apps/pano/app/models/user.server.ts
@@ -1,13 +1,14 @@
 import type {
   Password,
   User as PrismaUser,
-  UserPreference,
+  UserPreference as PrismaUserPreference,
 } from "@prisma/client";
 import { Theme } from "@prisma/client";
 import bcrypt from "bcryptjs";
 import { prisma } from "~/db.server";
 
 export type User = PrismaUser;
+export type UserPreference = PrismaUserPreference;
 
 export async function getUserById(id: User["id"]) {
   return prisma.user.findUnique({ where: { id } });

--- a/apps/pano/app/routes/change-theme.tsx
+++ b/apps/pano/app/routes/change-theme.tsx
@@ -1,5 +1,5 @@
-import { ActionFunction } from "@remix-run/node";
-import { useUserContext } from "~/features/auth/user-context";
+import type { ActionFunction } from "@remix-run/node";
+import type { UserPreference } from "~/models/user.server";
 import { updateTheme } from "~/models/user.server";
 import { requireUser } from "~/session.server";
 
@@ -7,7 +7,7 @@ export const action: ActionFunction = async ({ request }) => {
   const formData = await request.formData();
   const user = await requireUser(request);
 
-  const theme = formData.get("theme");
+  const theme = formData.get("theme") as UserPreference["theme"];
 
   try {
     await updateTheme(user, theme);

--- a/apps/pano/app/routes/posts/$id.edit.tsx
+++ b/apps/pano/app/routes/posts/$id.edit.tsx
@@ -15,7 +15,6 @@ import { json } from "@remix-run/node";
 import { useActionData, useLoaderData, useTransition } from "@remix-run/react";
 import normalizeUrl from "normalize-url";
 import type { FC } from "react";
-import { useState } from "react";
 import invariant from "tiny-invariant";
 import { canUserEdit } from "~/features/auth/can-user-edit";
 import type { PostWithCommentCount } from "~/models/post.server";

--- a/apps/pano/app/routes/send.tsx
+++ b/apps/pano/app/routes/send.tsx
@@ -14,7 +14,7 @@ import { useFetcher, useTransition } from "@remix-run/react";
 import normalizeUrl from "normalize-url";
 import { createPost } from "~/models/post.server";
 import { requireUserId } from "~/session.server";
-import { validate, validateURL, getPostLink } from "~/utils";
+import { getPostLink, validate, validateURL } from "~/utils";
 
 type ActionData = {
   error: {
@@ -59,6 +59,8 @@ export const action: ActionFunction = async ({ request }) => {
 
   try {
     const post = await createPost(title, userID, url, body);
+    // FIXME: getPostLink required PostWithCommentCount,
+    // but createPost returns Post
     return redirect(getPostLink(post));
   } catch (e) {
     return json(e, { status: 500 });

--- a/apps/pano/app/session.server.ts
+++ b/apps/pano/app/session.server.ts
@@ -1,9 +1,9 @@
 import { createCookieSessionStorage, redirect } from "@remix-run/node";
 import invariant from "tiny-invariant";
+import { env } from "./utils/env.server";
 import type { User } from "~/models/user.server";
 import { getTheme } from "~/models/user.server";
 import { getUserById } from "~/models/user.server";
-import { env } from "./utils/env.server";
 
 invariant(env.SESSION_SECRET, "SESSION_SECRET must be set");
 


### PR DESCRIPTION
I've scanned through all the files in the repo in order to fix some import and type issues such as:

-  wrong imports,
-  redundant imports,
-  incorrectly ordered types.

Created a new type in `user.model` to use it in `change-theme` where `updateTheme()` function requires `Theme` parameter, without it causes error.

Finally, I've created two new FIXME's, I don't know if those are deliberately existing, but I just wanted to point out.