### PR TITLE
fix(@kampus-apps/pano): add otp to pano package.json

### DIFF
--- a/apps/pano/package.json
+++ b/apps/pano/package.json
@@ -50,6 +50,7 @@
     "react-dom": "18.2.0",
     "remix-auth": "3.4.0",
     "remix-auth-form": "1.3.0",
+    "remix-auth-otp": "2.2.0",
     "slugify": "1.6.5",
     "tiny-invariant": "1.3.1",
     "znv": "0.3.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,6 @@
         "packages/*"
       ],
       "dependencies": {
-        "remix-auth-otp": "2.2.0",
         "turbo": "1.8.3"
       }
     },
@@ -44,6 +43,7 @@
         "react-dom": "18.2.0",
         "remix-auth": "3.4.0",
         "remix-auth-form": "1.3.0",
+        "remix-auth-otp": "2.2.0",
         "slugify": "1.6.5",
         "tiny-invariant": "1.3.1",
         "znv": "0.3.2",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,6 @@
   },
   "homepage": "https://github.com/kamp-us/monorepo#readme",
   "dependencies": {
-    "remix-auth-otp": "2.2.0",
     "turbo": "1.8.3"
   },
   "volta": {


### PR DESCRIPTION
`remix-auth-otp` package was installed on the main folder so this is giving errors. This should be installed on pano.