### PR TITLE
fix: handle text overflow on all screen size

### DIFF
--- a/apps/pano/app/features/comment/Comment.tsx
+++ b/apps/pano/app/features/comment/Comment.tsx
@@ -123,7 +123,11 @@ export const CommentItem: FC<CommentProps> = ({
             <Text
               size="3"
               lineHeight="2"
-              css={{ color: "$gray12", whiteSpace: "break-spaces" }}
+              css={{
+                color: "$gray12",
+                whiteSpace: "break-spaces",
+                wordBreak: "break-word",
+              }}
             >
               {comment.content}
             </Text>

--- a/apps/pano/app/features/post/PostItem.tsx
+++ b/apps/pano/app/features/post/PostItem.tsx
@@ -47,10 +47,15 @@ export const PostItem: FC<PostItemProps> = ({ post, showContent = false }) => {
 
   const titleLink = post.url ? (
     <ExternalLink
-      style={{
-        textOverflow: "ellipsis",
-        whiteSpace: "nowrap",
+      css={{
+        wordBreak: "break-word",
+        "--line-clamp": 3,
+        lineHeight: "1.2",
+        maxHeight: "calc(1.2em * var(--line-clamp))",
         overflow: "hidden",
+        display: "-webkit-box",
+        "-webkit-line-clamp": "var(--line-clamp)",
+        "-webkit-box-orient": "vertical",
       }}
       href={normalizeUrl(post.url)}
     >
@@ -59,10 +64,15 @@ export const PostItem: FC<PostItemProps> = ({ post, showContent = false }) => {
   ) : (
     <InternalLink
       to={getPostLink(post)}
-      style={{
-        textOverflow: "ellipsis",
-        whiteSpace: "nowrap",
+      css={{
+        wordBreak: "break-word",
+        "--line-clamp": 3,
+        lineHeight: "1.2",
+        maxHeight: "calc(1.2em * var(--line-clamp))",
         overflow: "hidden",
+        display: "-webkit-box",
+        "-webkit-line-clamp": "var(--line-clamp)",
+        "-webkit-box-orient": "vertical",
       }}
     >
       {post.title}
@@ -82,10 +92,24 @@ export const PostItem: FC<PostItemProps> = ({ post, showContent = false }) => {
           <input type="hidden" name="json" value={JSON.stringify(variables)} />
         </fetcher.Form>
         <GappedBox css={{ flexDirection: "column", width: "100%" }}>
-          <GappedBox css={{ alignItems: "baseline" }}>
+          <GappedBox css={{ alignItems: "baseline", flexWrap: "wrap" }}>
             {titleLink}
             {post.site && (
-              <SmallLink to={getSitePostsLink(post)}>{post.site}</SmallLink>
+              <SmallLink
+                to={getSitePostsLink(post)}
+                css={{
+                  wordBreak: "break-word",
+                  "--line-clamp": 1,
+                  lineHeight: "1.2",
+                  maxHeight: "calc(1.2em * var(--line-clamp))",
+                  overflow: "hidden",
+                  display: "-webkit-box",
+                  "-webkit-line-clamp": "var(--line-clamp)",
+                  "-webkit-box-orient": "vertical",
+                }}
+              >
+                {post.site}
+              </SmallLink>
             )}
           </GappedBox>
           <GappedBox
@@ -115,6 +139,7 @@ export const PostItem: FC<PostItemProps> = ({ post, showContent = false }) => {
                 borderRadius: 4,
                 border: "1px solid $gray7",
                 backgroundColor: "$gray3",
+                wordBreak: "break-word",
               }}
             >
               <Text

--- a/apps/pano/app/features/post/PostItem.tsx
+++ b/apps/pano/app/features/post/PostItem.tsx
@@ -49,13 +49,7 @@ export const PostItem: FC<PostItemProps> = ({ post, showContent = false }) => {
     <ExternalLink
       css={{
         wordBreak: "break-word",
-        "--line-clamp": 3,
-        lineHeight: "1.2",
-        maxHeight: "calc(1.2em * var(--line-clamp))",
-        overflow: "hidden",
-        display: "-webkit-box",
-        "-webkit-line-clamp": "var(--line-clamp)",
-        "-webkit-box-orient": "vertical",
+        lineLimit: { count: 3, height: 1.2 },
       }}
       href={normalizeUrl(post.url)}
     >
@@ -66,13 +60,7 @@ export const PostItem: FC<PostItemProps> = ({ post, showContent = false }) => {
       to={getPostLink(post)}
       css={{
         wordBreak: "break-word",
-        "--line-clamp": 3,
-        lineHeight: "1.2",
-        maxHeight: "calc(1.2em * var(--line-clamp))",
-        overflow: "hidden",
-        display: "-webkit-box",
-        "-webkit-line-clamp": "var(--line-clamp)",
-        "-webkit-box-orient": "vertical",
+        lineLimit: { count: 3, height: 1.2 },
       }}
     >
       {post.title}
@@ -99,13 +87,7 @@ export const PostItem: FC<PostItemProps> = ({ post, showContent = false }) => {
                 to={getSitePostsLink(post)}
                 css={{
                   wordBreak: "break-word",
-                  "--line-clamp": 1,
-                  lineHeight: "1.2",
-                  maxHeight: "calc(1.2em * var(--line-clamp))",
-                  overflow: "hidden",
-                  display: "-webkit-box",
-                  "-webkit-line-clamp": "var(--line-clamp)",
-                  "-webkit-box-orient": "vertical",
+                  lineLimit: { count: 1, height: 1.2 },
                 }}
               >
                 {post.site}

--- a/apps/pano/app/features/post/PostSortFilters.tsx
+++ b/apps/pano/app/features/post/PostSortFilters.tsx
@@ -1,5 +1,6 @@
 import { GappedBox, SmallLink } from "@kampus/ui";
 import { useLocation } from "@remix-run/react";
+import { Fragment } from "react";
 
 const filters = [
   { url: "/", text: "hepsi" },
@@ -23,15 +24,15 @@ export const PostSortFilters = () => {
     >
       {filters.map(({ url, text }, index) => {
         return (
-          <>
+          <Fragment key={url}>
             <SmallLink
-              key={url}
               to={url}
               css={{ color: paintIfActive(url), whiteSpace: "nowrap" }}
             >
               {text}
-            </SmallLink>{`${index === filters.length -1 ? "" : " • "}`}            
-          </>
+            </SmallLink>
+            {`${index === filters.length - 1 ? "" : " • "}`}
+          </Fragment>
         );
       })}
     </GappedBox>

--- a/apps/pano/app/features/post/PostSortFilters.tsx
+++ b/apps/pano/app/features/post/PostSortFilters.tsx
@@ -14,12 +14,24 @@ export const PostSortFilters = () => {
     location.pathname === url ? "$amber11" : "none";
 
   return (
-    <GappedBox>
-      {filters.map(({ url, text }) => {
+    <GappedBox
+      css={{
+        alignItems: "center",
+        color: "$gray9",
+        flexWrap: "wrap",
+      }}
+    >
+      {filters.map(({ url, text }, index) => {
         return (
-          <SmallLink key={url} to={url} css={{ color: paintIfActive(url) }}>
-            {text}
-          </SmallLink>
+          <>
+            <SmallLink
+              key={url}
+              to={url}
+              css={{ color: paintIfActive(url), whiteSpace: "nowrap" }}
+            >
+              {text}
+            </SmallLink>{`${index === filters.length -1 ? "" : " • "}`}            
+          </>
         );
       })}
     </GappedBox>

--- a/packages/kampus-ui/src/stitches.config.ts
+++ b/packages/kampus-ui/src/stitches.config.ts
@@ -232,6 +232,22 @@ export const { styled, createTheme, getCssText, config, keyframes, reset } =
         WebkitBackgroundClip: value,
         backgroundClip: value,
       }),
+
+      lineLimit: (value: {
+        count: number;
+        height: Stitches.PropertyValue<"lineHeight">;
+      }) => {
+        const { height, count } = value;
+        const lineH = typeof height === "number" ? `${height}em` : height;
+        return {
+          lineHeight: height,
+          maxHeight: `calc(${lineH} * ${count})`,
+          overflow: "hidden",
+          display: "-webkit-box",
+          "-webkit-line-clamp": count,
+          "-webkit-box-orient": "vertical",
+        };
+      },
     },
   });
 


### PR DESCRIPTION
Fixes #291 

- [x] 1. Post title should appear regardless of the URL text length.
- [x] 2. Overflow of post title and link should be handled on small screen sizes.
- [x] 3. Filter texts should be one line text and overflow should be handled on small screen sizes.
- [x] 4. The more button should not overflow on small screen sizes.
- [x] 5. Post URL and content should not overflow.
- [x] 6. Comments should not overflow.

_Notes: Post title is limited to 3 line and URL is limited to 1 line. ~~The line number can be changed with one CSS variable~~ (Refactored, now it can be changed with stitches util). And I think post title character length should be limited to some number when creating a post. Since the title line limit is affects both post detail and post on home page, so very long titles can not be fully shown on mobile with current implementation. Also it generates really long post URL like `posts/aaaaaaaaaaa..../cuid`_


1.
![image](https://user-images.githubusercontent.com/59164130/223474766-54f51f31-43d2-4aa9-aa4d-393c21265ccd.png)
![image](https://user-images.githubusercontent.com/59164130/223475146-d740eaea-1e73-48c1-a79c-a6ec7fd22b96.png)

2.
![image](https://user-images.githubusercontent.com/59164130/223475264-ec7fc17c-c946-41c7-86be-e3cc2566bfe3.png)
![image](https://user-images.githubusercontent.com/59164130/223475370-41d0f5d8-6a8c-4757-8f5b-2436b30f4e6b.png)

3.
![image](https://user-images.githubusercontent.com/59164130/223475590-36e5e397-790d-4298-8ae1-a664e7aae84d.png)

4.
![image](https://user-images.githubusercontent.com/59164130/223475748-8cc69016-f283-4afd-96a1-abcbfbca522c.png)

5.
![image](https://user-images.githubusercontent.com/59164130/223475998-e1ac060e-b677-4d94-9ae9-ac4073b84cad.png)
![image](https://user-images.githubusercontent.com/59164130/223476054-acd4be58-38da-4ebe-9928-a09f05a31102.png)

6.
![image](https://user-images.githubusercontent.com/59164130/223476216-f78ca11d-5991-4a8f-ac67-477dc188fd21.png)
![image](https://user-images.githubusercontent.com/59164130/223476270-b8903f23-7b5f-47eb-b3b0-184a14cad12f.png)

