### PR TITLE
feat: implement time frame for most popular posts

### DIFF
--- a/apps/pano/app/features/post/PopularPostsTimeframeFilters.tsx
+++ b/apps/pano/app/features/post/PopularPostsTimeframeFilters.tsx
@@ -1,0 +1,64 @@
+import {
+  DropdownMenu,
+  DropdownMenuTrigger,
+  OldButton,
+  DropdownMenuContent,
+} from "@kampus/ui";
+import { Form, useLocation, useNavigation } from "@remix-run/react";
+import { useEffect, useState } from "react";
+
+export const TIME_FRAMES = [
+  { text: "Now", value: "now" },
+  { text: "Today", value: "today" },
+  { text: "This Week", value: "week" },
+  { text: "This Month", value: "month" },
+  { text: "This Year", value: "year" },
+  { text: "All Time", value: "all" },
+] as const;
+
+export const PopularPostsTimeframeFilters = () => {
+  const [dropdownOpen, setDropdownOpen] = useState(false);
+
+  const navigation = useNavigation();
+  const location = useLocation();
+  const timeframe =
+    new URLSearchParams(location.search).get("timeframe") || "all";
+  const currentTimeframe =
+    TIME_FRAMES.find((t) => t.value === timeframe)?.text || "All Time";
+
+  // TODO: I don't know if this is the best way to close the dropdown,
+  // but it works for now, I've tried to add onClick listeners to the buttons
+  // but getting 'form submission canceled because the form is not connected'
+
+  // Maybe we should try to implement below solution for all dropdowns since,
+  // we pretty much need all dropdowns to close when we navigate to another page
+  useEffect(() => {
+    setDropdownOpen(false);
+  }, [navigation.state]);
+
+  return (
+    <DropdownMenu open={dropdownOpen}>
+      <DropdownMenuTrigger onClick={() => setDropdownOpen(true)} asChild>
+        <OldButton>{currentTimeframe}</OldButton>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent
+        style={{
+          display: "flex",
+        }}
+      >
+        <Form
+          action="/posts/hot"
+          style={{
+            display: "flex",
+          }}
+        >
+          {TIME_FRAMES.map(({ text, value }) => (
+            <OldButton key={value} type="submit" name="timeframe" value={value}>
+              {text}
+            </OldButton>
+          ))}
+        </Form>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+};

--- a/apps/pano/app/features/post/PostSortFilters.tsx
+++ b/apps/pano/app/features/post/PostSortFilters.tsx
@@ -1,5 +1,6 @@
 import { GappedBox, SmallLink } from "@kampus/ui";
 import { useLocation } from "@remix-run/react";
+import { PopularPostsTimeframeFilters } from "./PopularPostsTimeframeFilters";
 
 const filters = [
   { url: "/", text: "hepsi" },
@@ -11,12 +12,36 @@ const filters = [
 
 export const PostSortFilters = () => {
   const location = useLocation();
+
+  const isUrlActive = (url: string) => location.pathname === url;
   const paintIfActive = (url: string) =>
-    location.pathname === url ? "$amber11" : "none";
+    isUrlActive(url) ? "$amber11" : "none";
 
   return (
-    <GappedBox>
+    <GappedBox
+      style={{
+        display: "flex",
+        alignItems: "center",
+      }}
+    >
       {filters.map(({ url, text }) => {
+        if (isUrlActive(url) && url === "/posts/hot") {
+          return (
+            <GappedBox
+              key={url}
+              style={{
+                display: "flex",
+                alignItems: "center",
+              }}
+            >
+              <SmallLink to={url} css={{ color: paintIfActive(url) }}>
+                {text}
+              </SmallLink>
+              <PopularPostsTimeframeFilters />
+            </GappedBox>
+          );
+        }
+
         return (
           <SmallLink key={url} to={url} css={{ color: paintIfActive(url) }}>
             {text}

--- a/apps/pano/app/models/post.server.ts
+++ b/apps/pano/app/models/post.server.ts
@@ -4,6 +4,7 @@ import { prisma } from "~/db.server";
 import { getSitename } from "~/features/url/get-sitename";
 import type { Comment } from "~/models/comment.server";
 import { normalizeComment } from "~/models/comment.server";
+import { getStartDate } from "~/utils";
 
 const selectPostWithOwner = Prisma.validator<Prisma.PostArgs>()({
   include: {
@@ -99,11 +100,17 @@ export const getActivePosts = async () => {
   return activePosts;
 };
 
-export const getMostCommentedPosts = () => {
+export type Timeframe = "now" | "today" | "week" | "month" | "year" | "all";
+export const getMostCommentedPosts = (timeframe: Timeframe) => {
   return prisma.post.findMany({
     orderBy: {
       comments: {
         _count: "desc",
+      },
+    },
+    where: {
+      createdAt: {
+        gte: getStartDate(timeframe),
       },
     },
     include: {

--- a/apps/pano/app/routes/posts/__filters/hot.tsx
+++ b/apps/pano/app/routes/posts/__filters/hot.tsx
@@ -1,16 +1,19 @@
+import { LoaderArgs } from "@remix-run/node";
 import { useLoaderData } from "@remix-run/react";
-import type { LoaderFunction } from "react-router-dom";
 import { json } from "react-router-dom";
 import { PostList } from "~/features/post/PostList";
-import type { PostWithCommentCount } from "~/models/post.server";
+import type { Timeframe, PostWithCommentCount } from "~/models/post.server";
 import { getMostCommentedPosts } from "~/models/post.server";
 
 type LoaderData = {
   posts: PostWithCommentCount[];
 };
 
-export const loader: LoaderFunction = async () => {
-  const posts = await getMostCommentedPosts();
+export const loader = async ({ request }: LoaderArgs) => {
+  const url = new URL(request.url);
+  const timeframe = (url.searchParams.get("timeframe") || "all") as Timeframe;
+
+  const posts = await getMostCommentedPosts(timeframe);
 
   return json<LoaderData>({ posts });
 };

--- a/apps/pano/app/utils/index.ts
+++ b/apps/pano/app/utils/index.ts
@@ -1,5 +1,6 @@
 import { useMatches } from "@remix-run/react";
 import { useMemo } from "react";
+import { Timeframe } from "~/models/post.server";
 import type { User } from "~/models/user.server";
 
 const DEFAULT_REDIRECT = "/";
@@ -122,4 +123,25 @@ export function getPostLink(post: { slug: string; id: string }) {
 export function getSitePostsLink(post: { site: string }) {
   const postUrl = `/site/${post.site}`;
   return postUrl;
+}
+
+export function getStartDate(timeframe: Timeframe) {
+  const now = new Date();
+  switch (timeframe) {
+    case "now":
+      // in 5 minutes
+      return new Date(now.getTime() - 5 * 60 * 1000);
+    case "today":
+      return new Date(now.getFullYear(), now.getMonth(), now.getDate());
+    case "week":
+      return new Date(now.getFullYear(), now.getMonth(), now.getDate() - 7);
+    case "month":
+      return new Date(now.getFullYear(), now.getMonth(), now.getDate() - 30);
+    case "year":
+      return new Date(now.getFullYear(), now.getMonth(), now.getDate() - 365);
+    case "all":
+      return new Date(0);
+    default:
+      return new Date(0);
+  }
 }


### PR DESCRIPTION
Closes #304 

Looks like: 
![image](https://user-images.githubusercontent.com/73023004/224477819-a9b04a8b-b8d4-4455-8a0c-8c0615ae6f00.png)

![image](https://user-images.githubusercontent.com/73023004/224477838-5de6ab4f-8b9e-4745-a39e-572d27ade230.png)

![image](https://user-images.githubusercontent.com/73023004/224477848-0d46c268-9128-4084-ba4e-6154cb0e55bb.png)

![image](https://user-images.githubusercontent.com/73023004/224477859-bca5bd90-2bae-4167-8cd3-d4f30fc3ec62.png)

Pretty much works fine, although I need to mention a couple of things:

- I've defensively implemented the `search param parsing` in the `PopularPostsTimeframeFilters` component, checking if

1.   search parameter doesn't exist.
2.  exists but empty string
3. exists but invalid

- In the `/posts/hot route` and `hot.tsx` in particular, not checking if the search query `exists but invalid`, but it shouldn't be a problem since `returning default date` in the `getStartDate` function in utils, but for seperations of concern, we can keep util function pure (removing default case) and double check search parameter in loader.

- As you can see my comments at `PopularPostsTimeframeFilters`, need to discuss about how to handle closing dropdowns on navigating. 