### PR TITLE
fix: urlify links in commnet

### DIFF
--- a/apps/pano/app/features/comment/Comment.tsx
+++ b/apps/pano/app/features/comment/Comment.tsx
@@ -23,6 +23,7 @@ import { EditCommentForm } from "./EditCommentForm";
 import { MoreOptionsDropdown } from "./MoreOptionsDropdown";
 import { useUserContext } from "../auth/user-context";
 import { CommentUpvoteButton } from "../upvote/UpvoteButton";
+import { z } from 'zod';
 
 type CommentProps = {
   comment: Comment;
@@ -83,9 +84,10 @@ export const CommentItem: FC<CommentProps> = ({
   const urlify = (content: string) => {
     const urlRegex = /(https?:\/\/[^\s]+)/g;
     const splitted = content.split(urlRegex);
-
+    
     const urlified = splitted.map((part) => {
-      if (part.match(urlRegex)) {
+      const safeParseResponse = z.string().url().safeParse(part);
+      if (safeParseResponse.success) {
         return (
           <ExternalLink
             key={part}

--- a/apps/pano/app/features/comment/Comment.tsx
+++ b/apps/pano/app/features/comment/Comment.tsx
@@ -1,6 +1,7 @@
 import {
   Box,
   Button,
+  ExternalLink,
   Form,
   GappedBox,
   SmallLink,
@@ -79,6 +80,29 @@ export const CommentItem: FC<CommentProps> = ({
 
   const formRef = useRef<HTMLFormElement>(null);
 
+  const urlify = (content: string) => {
+    const urlRegex = /(https?:\/\/[^\s]+)/g;
+    const splitted = content.split(urlRegex);
+
+    const urlified = splitted.map((part) => {
+      if (part.match(urlRegex)) {
+        return (
+          <ExternalLink
+            key={part}
+            href={part}
+            target="_blank"
+            rel="noreferrer noopener"
+          >
+            {part}
+          </ExternalLink>
+        );
+      }
+      return part;
+    });
+
+    return urlified;
+  };
+
   useEffect(() => {
     if (!isCommenting && formRef.current) {
       setOpen(false);
@@ -140,7 +164,7 @@ export const CommentItem: FC<CommentProps> = ({
               lineHeight="2"
               css={{ color: "$gray12", whiteSpace: "break-spaces" }}
             >
-              {comment.content}
+              {urlify(comment.content)}
             </Text>
           )}
         </Box>


### PR DESCRIPTION
Fixes #303 

![image](https://user-images.githubusercontent.com/73023004/224479909-1809cbfc-e48b-483e-ad0b-2e05651f84b2.png)

Works fine for complete links such as https://google.com,  but "google.com" or "github.com" are not supported yet.