### PR TITLE
fix: login page SmallLink covers the whole page

### DIFF
--- a/apps/pano/app/routes/__auth/login.tsx
+++ b/apps/pano/app/routes/__auth/login.tsx
@@ -103,7 +103,9 @@ export const Login = () => {
             <Button size="2">Github ile giriş yap</Button>
           </Form>
         </GappedBox>
-        <SmallLink to="/login-form">Şifreyle giriş yapmak için tıkla</SmallLink>
+        <SmallLink to="/login-form" css={{ width: "fit-content" }}>
+          Şifreyle giriş yapmak için tıkla
+        </SmallLink>
       </GappedBox>
     </CenteredContainer>
   );


### PR DESCRIPTION
# Description

This Pull Request fixes the width of the SmallLink for "Şifreyle giriş yapmak için tıkla" in the login page. The link will now only be clickable when hovering over it and will not cover the entire page width.

### Checklist

- [  ] discord username: `username#0001`
- [x] Closes #323
- [x] PR must be created for an issue from issues under "In progress" column from [our project board](https://github.com/orgs/kamp-us/projects/2/views/1).
- [x] A descriptive and understandable title: The PR title should clearly describe the nature and purpose of the changes. The PR title should be the first thing displayed when the PR is opened. And it should follow the semantic commit rules, and should include the app/package/service name in the title. For example, a title like "docs(@kampus-apps/pano): Add README.md" can be used.
- [x] Related file selection: Only relevant files should be touched and no other files should be affected.
- [x] I ran `npx turbo run` at the root of the repository, and build was successful.
- [x] I installed the npm packages using `npm install --save-exact <package>` so my package is pinned to a specific npm version. Leave empty if no package was installed. Leave empty if no package was installed with this PR.

### How were these changes tested?
1. Go to the login page.
2. Note that the SmallLink for "Şifreyle giriş yapmak için tıkla" no longer covers the entire page width.
3. Confirm that the link is clickable only when hovering over it.

https://user-images.githubusercontent.com/88425310/224707344-5c9d5da4-59a5-446e-884a-dfd269fb981a.mov
