### PR TITLE
fix: background color issue in AutoFill select fields

### DIFF
--- a/packages/kampus-ui/src/Input.tsx
+++ b/packages/kampus-ui/src/Input.tsx
@@ -27,11 +27,19 @@ export const Input = styled("input", {
   "&:-webkit-autofill": {
     boxShadow:
       "inset 0 0 0 1px $colors$amber6, inset 0 0 0 100px $colors$amber3",
+    transition: "background-color 600000s 0s, color 600000s 0s",
   },
 
   "&:-webkit-autofill::first-line": {
     fontFamily: "$inter",
     color: "$hiContrast",
+  },
+
+  "&:-webkit-autofill:focus": {
+    transition: "background-color 600000s 0s, color 600000s 0s",
+  },
+  "&[data-autocompleted]": {
+    backgroundColor: "transparent !important",
   },
 
   "&:focus": {


### PR DESCRIPTION
# Description
Fixes unexpected background color change in select areas when using AutoFill feature. This change may cause confusion for users and negatively affect the overall user experience. With this PR, it is ensured that the select areas retain their original background color.
### Checklist

- [ ] discord username: `username#0001`
- [ x ] Closes #325 
- [ x ] PR must be created for an issue from issues under "In progress" column from [our project board](https://github.com/orgs/kamp-us/projects/2/views/1).
- [ x ] A descriptive and understandable title: The PR title should clearly describe the nature and purpose of the changes. The PR title should be the first thing displayed when the PR is opened. And it should follow the semantic commit rules, and should include the app/package/service name in the title. For example, a title like "docs(@kampus-apps/pano): Add README.md" can be used.
- [ x ] Related file selection: Only relevant files should be touched and no other files should be affected.
- [ x ] I ran `npx turbo run` at the root of the repository, and build was successful.
- [ x ] I installed the npm packages using `npm install --save-exact <package>` so my package is pinned to a specific npm version. Leave empty if no package was installed. Leave empty if no package was installed with this PR.

### How were these changes tested?

1. Click on a selected area with AutoFill enabled.
2. Start typing to trigger the AutoFill pop-up menu.
3. Select one of the suggestions from the drop-down menu.
4. See that the background color of the area is not white

https://user-images.githubusercontent.com/88425310/224733231-bb165b9c-5a83-424b-8c6c-bc9a95eaa9a4.mov

