### PR TITLE
fix(apps/pano): generated suffix for usernames are floats instead of …

### DIFF
--- a/apps/pano/app/features/authenticator/strategies.ts
+++ b/apps/pano/app/features/authenticator/strategies.ts
@@ -96,7 +96,8 @@ export const strategies = {
             },
           });
 
-          if (usernameConflict) generatedUsername += Math.random() * 10000;
+          if (usernameConflict)
+            generatedUsername += Math.floor(Math.random() * 10000);
         } while (usernameConflict);
         user = await prisma.user.create({
           data: { email, username: generatedUsername },


### PR DESCRIPTION
…integers

# Description

A simple one-liner that turns generated suffix into an integer.

### Checklist

- [X] discord username: `bumshaqalaqa#2973`
- [X] Closes #328 
- [X] PR must be created for an issue from issues under "In progress" column from [our project board](https://github.com/orgs/kamp-us/projects/2/views/1).
- [X] A descriptive and understandable title: The PR title should clearly describe the nature and purpose of the changes. The PR title should be the first thing displayed when the PR is opened. And it should follow the semantic commit rules, and should include the app/package/service name in the title. For example, a title like "docs(@kampus-apps/pano): Add README.md" can be used.
- [X] Related file selection: Only relevant files should be touched and no other files should be affected.
- [X] I ran `npx turbo run` at the root of the repository, and build was successful.
- [X] I installed the npm packages using `npm install --save-exact <package>` so my package is pinned to a specific npm version. Leave empty if no package was installed. Leave empty if no package was installed with this PR.

### How were these changes tested?

Changes are not tested for this pr
