### PR TITLE
refactor: add spacing to buttons for comment edit

### DIFF
--- a/apps/pano/app/features/comment/EditCommentForm.tsx
+++ b/apps/pano/app/features/comment/EditCommentForm.tsx
@@ -1,4 +1,4 @@
-import { Button, Textarea } from "@kampus/ui";
+import { Button, GappedBox, Textarea } from "@kampus/ui";
 import { useFetcher } from "@remix-run/react";
 import type { FC } from "react";
 import { useEffect } from "react";
@@ -30,16 +30,20 @@ export const EditCommentForm: FC<EditCommentProps> = ({
 
   return (
     <fetcher.Form method="post" action="/commentEdit">
-      <Textarea
-        name="comment"
-        defaultValue={comment.content}
-        onChange={(event) => setEditedComment(event.target.value)}
-      />
-      <input type="hidden" name="json" value={JSON.stringify(variables)} />
-      <Button type="submit">
-        {isCommenting ? "Kaydediliyor..." : "Kaydet"}
-      </Button>
-      <Button onClick={() => setEditOpen(false)}>İptal</Button>
+      <GappedBox css={{ flexDirection: "column" }}>
+        <Textarea
+          name="comment"
+          defaultValue={comment.content}
+          onChange={(event) => setEditedComment(event.target.value)}
+        />
+        <input type="hidden" name="json" value={JSON.stringify(variables)} />
+        <GappedBox>
+          <Button type="submit">
+            {isCommenting ? "Kaydediliyor..." : "Kaydet"}
+          </Button>
+          <Button onClick={() => setEditOpen(false)}>İptal</Button>
+        </GappedBox>
+      </GappedBox>
     </fetcher.Form>
   );
 };


### PR DESCRIPTION
# Description

The problem that there is no space between the textarea and the buttons when using the Firefox browser has been resolved, and a space is left between the two buttons.

### Checklist

- [ ] discord username: `username#0001`
- [x] Closes #334 
- [x] PR must be created for an issue from issues under "In progress" column from [our project board](https://github.com/orgs/kamp-us/projects/2/views/1).
- [x] A descriptive and understandable title: The PR title should clearly describe the nature and purpose of the changes. The PR title should be the first thing displayed when the PR is opened. And it should follow the semantic commit rules, and should include the app/package/service name in the title. For example, a title like "docs(@kampus-apps/pano): Add README.md" can be used.
- [x] Related file selection: Only relevant files should be touched and no other files should be affected.
- [x] I ran `npx turbo run` at the root of the repository, and build was successful.
- [x] I installed the npm packages using `npm install --save-exact <package>` so my package is pinned to a specific npm version. Leave empty if no package was installed. Leave empty if no package was installed with this PR.

### How were these changes tested?
1. sign in
2. Press the edit button of a comment you have written
3. Verify that there is a space between the textarea and the buttons
4. Verify that there is a space between the buttons (Save, cancel)

safari: 
![Screenshot 2023-03-19 at 11 06 14 AM](https://user-images.githubusercontent.com/88425310/226162025-dd184974-81d7-4ce2-a8bd-c5cd837594ea.png)

Google Chorme: 
![Screenshot 2023-03-19 at 11 06 42 AM](https://user-images.githubusercontent.com/88425310/226162066-eca33714-f2ad-48d3-8783-a238429e37fd.png)

Brave: 
![Screenshot 2023-03-19 at 11 07 25 AM](https://user-images.githubusercontent.com/88425310/226162093-a722da4c-5c79-40d1-ba93-476bf9d40470.png)

Firefox:
![Screenshot 2023-03-19 at 11 07 59 AM](https://user-images.githubusercontent.com/88425310/226162118-e8b9d49b-b07e-4942-a2d8-a4910ad0434b.png)
