### PR TITLE
refactor: change alert modal buttons

### DIFF
--- a/apps/pano/app/features/comment/CommentDeleteAlert.tsx
+++ b/apps/pano/app/features/comment/CommentDeleteAlert.tsx
@@ -32,7 +32,7 @@ const CommentDeleteAlert = ({ commentID, open, setOpen }: AlertDialogProps) => {
         </AlertDialogDescription>
         <GappedBox css={{ justifyContent: "flex-end" }}>
           <AlertDialogCancel asChild onClick={() => setOpen(false)}>
-            <Button variant="green" css={{ marginRight: 25 }}>
+            <Button variant="gray" css={{ marginRight: 25 }}>
               Hayır
             </Button>
           </AlertDialogCancel>

--- a/apps/pano/app/features/post/PostDeleteAlert.tsx
+++ b/apps/pano/app/features/post/PostDeleteAlert.tsx
@@ -32,7 +32,7 @@ const PostDeleteAlert = ({ postID, open, setOpen }: AlertDialogProps) => {
         </AlertDialogDescription>
         <GappedBox css={{ justifyContent: "flex-end" }}>
           <AlertDialogCancel asChild onClick={() => setOpen(false)}>
-            <Button variant="green" css={{ marginRight: 25 }}>
+            <Button variant="gray" css={{ marginRight: 25 }}>
               Hayır
             </Button>
           </AlertDialogCancel>


### PR DESCRIPTION
# Description
This PR updates the variant of 'CommentDeleteAlert' and 'PostDeleteAlert' buttons to gray

### Checklist

- [ ] discord username: `username#0001`
- [x] Closes #335
- [x] PR must be created for an issue from issues under "In progress" column from [our project board](https://github.com/orgs/kamp-us/projects/2/views/1).
- [x] A descriptive and understandable title: The PR title should clearly describe the nature and purpose of the changes. The PR title should be the first thing displayed when the PR is opened. And it should follow the semantic commit rules, and should include the app/package/service name in the title. For example, a title like "docs(@kampus-apps/pano): Add README.md" can be used.
- [x] Related file selection: Only relevant files should be touched and no other files should be affected.
- [x] I ran `npx turbo run` at the root of the repository, and build was successful.
- [x] I installed the npm packages using `npm install --save-exact <package>` so my package is pinned to a specific npm version. Leave empty if no package was installed. Leave empty if no package was installed with this PR.

### How were these changes tested?

1. sign in
2. Press the button to delete a post you have written
3. Check that the 'hayır' button is in the gray variant

current behavior:
![Screenshot 2023-03-19 at 12 21 06 PM](https://user-images.githubusercontent.com/88425310/226165689-e30a477c-632f-463e-8bbe-84c52ea79646.png)
