### PR TITLE
fix: add validation to prevent empty comments

### DIFF
--- a/apps/pano/app/features/comment/EditCommentForm.tsx
+++ b/apps/pano/app/features/comment/EditCommentForm.tsx
@@ -12,7 +12,7 @@ type EditCommentProps = {
 };
 
 const commentSchema = z.object({
-  content: z.string().min(1, "Yorum boş gönderilemez."),
+  content: z.string().trim().min(1, "Yorum boş gönderilemez."),
 });
 
 export const EditCommentForm: FC<EditCommentProps> = ({
@@ -30,7 +30,7 @@ export const EditCommentForm: FC<EditCommentProps> = ({
 
   const validationResult = commentSchema.safeParse({ content: editedComment });
   const errorMessage = validationResult.success
-    ? undefined
+    ? null
     : validationResult.error?.errors[0].message;
 
   useEffect(() => {
@@ -40,7 +40,14 @@ export const EditCommentForm: FC<EditCommentProps> = ({
   }, [fetcher.type, setEditOpen]);
 
   return (
-    <fetcher.Form method="post" action="/commentEdit">
+    <fetcher.Form
+      method="post"
+      action="/commentEdit"
+      onSubmit={(event) => {
+        event.preventDefault();
+        !errorMessage && fetcher.submit(event.currentTarget);
+      }}
+    >
       <GappedBox css={{ flexDirection: "column" }}>
         <Textarea
           name="comment"

--- a/apps/pano/app/features/comment/EditCommentForm.tsx
+++ b/apps/pano/app/features/comment/EditCommentForm.tsx
@@ -1,9 +1,11 @@
-import { Button, GappedBox, Textarea } from "@kampus/ui";
+import { Button, GappedBox, Textarea, ValidationMessage } from "@kampus/ui";
 import { useFetcher } from "@remix-run/react";
 import type { FC } from "react";
 import { useEffect } from "react";
 import { useState } from "react";
 import type { Comment } from "~/models/comment.server";
+import { validate } from "~/utils";
+
 type EditCommentProps = {
   comment: Comment;
   setEditOpen: React.Dispatch<React.SetStateAction<boolean>>;
@@ -14,6 +16,7 @@ export const EditCommentForm: FC<EditCommentProps> = ({
   setEditOpen,
 }) => {
   const [editedComment, setEditedComment] = useState(comment.content);
+  const [error, setError] = useState("");
   const fetcher = useFetcher();
   const isCommenting =
     fetcher.state === "submitting" || fetcher.state === "loading";
@@ -28,20 +31,35 @@ export const EditCommentForm: FC<EditCommentProps> = ({
     }
   }, [fetcher.type, setEditOpen]);
 
+  const handleCommentChange = (
+    event: React.ChangeEvent<HTMLTextAreaElement>
+  ) => {
+    const value = event.target.value;
+    if (validate(value)) {
+      setEditedComment(value);
+      setError("");
+    } else {
+      setError("Yorum boş gönderilemez.");
+    }
+  };
+
   return (
     <fetcher.Form method="post" action="/commentEdit">
       <GappedBox css={{ flexDirection: "column" }}>
         <Textarea
           name="comment"
           defaultValue={comment.content}
-          onChange={(event) => setEditedComment(event.target.value)}
+          onChange={handleCommentChange}
         />
         <input type="hidden" name="json" value={JSON.stringify(variables)} />
         <GappedBox>
-          <Button type="submit">
+          <Button type="submit" disabled={error ? true : false}>
             {isCommenting ? "Kaydediliyor..." : "Kaydet"}
           </Button>
           <Button onClick={() => setEditOpen(false)}>İptal</Button>
+          {error && (
+            <ValidationMessage error={error} isSubmitting={isCommenting} />
+          )}
         </GappedBox>
       </GappedBox>
     </fetcher.Form>

--- a/apps/pano/app/features/comment/EditCommentForm.tsx
+++ b/apps/pano/app/features/comment/EditCommentForm.tsx
@@ -12,7 +12,7 @@ type EditCommentProps = {
 };
 
 const commentSchema = z.object({
-  content: z.string().min(1, "Yorum alanı boş bırakılamaz."),
+  content: z.string().min(1, "Yorum boş gönderilemez."),
 });
 
 export const EditCommentForm: FC<EditCommentProps> = ({


### PR DESCRIPTION
# Description

This PR adds validation to prevent empty comments in the EditCommentForm. If the user tries to submit an empty comment, an error message is displayed, and the submit button is disabled until valid input is entered.

### Checklist

- [x] discord username: `antipator#8808`
- [x] Closes #358 
- [ ] PR must be created for an issue from issues under "In progress" column from [our project board](https://github.com/orgs/kamp-us/projects/2/views/1).
- [x] A descriptive and understandable title: The PR title should clearly describe the nature and purpose of the changes. The PR title should be the first thing displayed when the PR is opened. And it should follow the semantic commit rules, and should include the app/package/service name in the title. For example, a title like "docs(@kampus-apps/pano): Add README.md" can be used.
- [x] Related file selection: Only relevant files should be touched and no other files should be affected.
- [x] I ran `npx turbo run` at the root of the repository, and build was successful.
- [ ] I installed the npm packages using `npm install --save-exact <package>` so my package is pinned to a specific npm version. Leave empty if no package was installed. Leave empty if no package was installed with this PR.

### How were these changes tested?
1. Go to the post page.
2. Create a comment.
3. Click the "Edit" button and delete the comment content.
4. Try to submit the form.
5. Write content to the comment.
6. Click the "Save" button.

![pano-empty-comment-fix](https://user-images.githubusercontent.com/53970699/229314281-87c27465-a37c-4407-8780-da54792b2333.gif)

