### PR TITLE
feat(apps/pano): Notification service

### DIFF
--- a/apps/pano/app/features/comment/Comment.tsx
+++ b/apps/pano/app/features/comment/Comment.tsx
@@ -72,7 +72,6 @@ export const CommentItem: FC<CommentProps> = ({
   });
   const location = useLocation();
   const targetHash = location.state?.targetHash;
-
   const variables = user
     ? isUpvoted
       ? getVariables("delete", { commentID: comment.id, userID: user.id })
@@ -103,7 +102,14 @@ export const CommentItem: FC<CommentProps> = ({
         css={{
           flexDirection: "column",
           transition: "background-color 0.3s",
-          "&:target, &.target": {
+          "&:target": !targetHash
+            ? {
+                backgroundColor: "$amber4",
+                borderRadius: "8px",
+                padding: "5px",
+              }
+            : {},
+          "&.target": {
             backgroundColor: "$amber4",
             borderRadius: "8px",
             padding: "5px",

--- a/apps/pano/app/features/comment/Comment.tsx
+++ b/apps/pano/app/features/comment/Comment.tsx
@@ -11,7 +11,7 @@ import {
   ValidationMessage,
 } from "@kampus/ui";
 import type { SerializeFrom } from "@remix-run/node";
-import { useFetcher, useTransition } from "@remix-run/react";
+import { useFetcher, useLocation, useTransition } from "@remix-run/react";
 import type { FC } from "react";
 import { useEffect, useRef, useState } from "react";
 import { useConfigContext } from "~/features/config/config-context";
@@ -70,6 +70,8 @@ export const CommentItem: FC<CommentProps> = ({
     comment,
     post,
   });
+  const location = useLocation();
+  const targetHash = location.state?.targetHash;
 
   const variables = user
     ? isUpvoted
@@ -96,11 +98,12 @@ export const CommentItem: FC<CommentProps> = ({
     <GappedBox css={{ flexDirection: "column" }}>
       <GappedBox
         id={`c_${comment.id}`}
+        className={targetHash === comment.id ? "target" : ""}
         tabIndex={0}
         css={{
           flexDirection: "column",
           transition: "background-color 0.3s",
-          "&:target": {
+          "&:target, &.target": {
             backgroundColor: "$amber4",
             borderRadius: "8px",
             padding: "5px",

--- a/apps/pano/app/features/comment/Comment.tsx
+++ b/apps/pano/app/features/comment/Comment.tsx
@@ -14,14 +14,14 @@ import type { SerializeFrom } from "@remix-run/node";
 import { useFetcher, useLocation, useTransition } from "@remix-run/react";
 import type { FC } from "react";
 import { useEffect, useRef, useState } from "react";
-import { useConfigContext } from "~/features/config/config-context";
-import type { Comment } from "~/models/comment.server";
-import type { Post } from "~/models/post.server";
-import { getExternalCommentURL } from "~/utils";
 import { EditCommentForm } from "./EditCommentForm";
 import { MoreOptionsDropdown } from "./MoreOptionsDropdown";
 import { useUserContext } from "../auth/user-context";
 import { CommentUpvoteButton } from "../upvote/UpvoteButton";
+import { useConfigContext } from "~/features/config/config-context";
+import type { Comment } from "~/models/comment.server";
+import type { Post } from "~/models/post.server";
+import { getExternalCommentURL } from "~/utils";
 
 type CommentProps = {
   comment: Comment;

--- a/apps/pano/app/features/notification-dropdown/NotificationDropdown.tsx
+++ b/apps/pano/app/features/notification-dropdown/NotificationDropdown.tsx
@@ -1,0 +1,76 @@
+import {
+  Button,
+  DropdownMenu,
+  DropdownMenuArrow,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+  IconButton,
+  Link,
+  styled,
+  UserAvatar,
+} from "@kampus/ui";
+import { Notification, User } from "@prisma/client";
+import { PlusIcon } from "@radix-ui/react-icons";
+import { useFetcher } from "@remix-run/react";
+import { FC, Fragment, useEffect } from "react";
+
+const MenuItem = styled(DropdownMenuItem, {
+  width: "auto",
+  cursor: "pointer",
+});
+
+const MenuLink = styled(Link, {
+  textDecoration: "none",
+});
+
+interface Props {
+  user: User;
+}
+
+export const NotificationDropdown: FC<Props> = (props) => {
+  const fetcher = useFetcher();
+
+  useEffect(() => {
+    console.log(fetcher);
+    if (fetcher.state === "idle" && fetcher.data == null) {
+      fetcher.load("/notifications/my-notifications");
+    }
+  }, [fetcher]);
+
+  useEffect(() => {
+    console.log(fetcher.data);
+  }, [fetcher.data]);
+
+  return (
+    <DropdownMenu>
+      <fetcher.Form method="get" action="/notification/my-notifications">
+        <DropdownMenuTrigger asChild>
+          <IconButton
+            color="transparent"
+            css={{
+              padding: 0,
+              borderRadius: "50%",
+              width: "auto",
+              height: "auto",
+            }}
+          >
+            <PlusIcon />
+          </IconButton>
+        </DropdownMenuTrigger>
+      </fetcher.Form>
+
+      <DropdownMenuContent sideOffset={5}>
+        {fetcher.data?.notifications.map((notif: Notification) => (
+          <Fragment key={notif.id}>
+            <MenuItem>{notif.type}</MenuItem>
+            <DropdownMenuSeparator />
+          </Fragment>
+        ))}
+        <DropdownMenuSeparator />
+        <DropdownMenuArrow offset={12} />
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+};

--- a/apps/pano/app/features/notification-dropdown/NotificationDropdown.tsx
+++ b/apps/pano/app/features/notification-dropdown/NotificationDropdown.tsx
@@ -60,12 +60,12 @@ export const NotificationDropdown: FC<Props> = (props) => {
               `${notif.triggeredBy.username} isimli kullanıcı "${notif.post.title}" paylaşımınıza bir yorum yaptı.`
             );
             break;
-          case "UPVOTECOMMENT":
+          case "UPVOTEPOST":
             messageArray.push(
               `${notif.triggeredBy.username} isimli kullanıcı "${notif.post.title}" paylaşımınızı beğendi.`
             );
             break;
-          case "UPVOTEPOST":
+          case "UPVOTECOMMENT":
             messageArray.push(
               `${
                 notif.triggeredBy.username
@@ -105,7 +105,7 @@ export const NotificationDropdown: FC<Props> = (props) => {
               <Fragment key={notif.id}>
                 <MenuLink
                   to={notif.url}
-                  state={{ targetHash: notif.comment.id }}
+                  state={{ targetHash: notif.comment?.id }}
                 >
                   <MenuItem>{processedNotifications[index]}</MenuItem>
                 </MenuLink>

--- a/apps/pano/app/features/notification-dropdown/NotificationDropdown.tsx
+++ b/apps/pano/app/features/notification-dropdown/NotificationDropdown.tsx
@@ -1,17 +1,12 @@
 import {
-  Button,
   DropdownMenu,
-  DropdownMenuArrow,
   DropdownMenuContent,
   DropdownMenuItem,
-  DropdownMenuSeparator,
   DropdownMenuTrigger,
   IconButton,
   Link,
   styled,
-  UserAvatar,
 } from "@kampus/ui";
-import { Notification, User } from "@prisma/client";
 import { PlusIcon } from "@radix-ui/react-icons";
 import { useFetcher } from "@remix-run/react";
 import { FC, Fragment, useEffect, useState } from "react";

--- a/apps/pano/app/features/notification-dropdown/NotificationDropdown.tsx
+++ b/apps/pano/app/features/notification-dropdown/NotificationDropdown.tsx
@@ -2,6 +2,7 @@ import {
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
+  DropdownMenuSeparator,
   DropdownMenuTrigger,
   IconButton,
   Link,
@@ -34,6 +35,13 @@ export const NotificationDropdown: FC<Props> = (props) => {
     string[]
   >([]);
 
+  const handleRead = () => {
+    fetcher.submit(
+      {},
+      { method: "post", action: "/notifications/my-notifications" }
+    );
+  };
+
   useEffect(() => {
     if (fetcher.state === "idle" && fetcher.data == null) {
       fetcher.load("/notifications/my-notifications");
@@ -46,34 +54,38 @@ export const NotificationDropdown: FC<Props> = (props) => {
       (fetcher.data.notifications as MyNotification[]).forEach((notif) => {
         switch (notif.type) {
           case "REPLY":
-            messageArray.push(
-              `${
-                notif.triggeredBy.username
-              } isimli kullanıcı şu yorumunuzu yanıtladı: "${notif.comment.content.substring(
-                0,
-                30
-              )}..."`
-            );
+            if (notif.comment)
+              messageArray.push(
+                `${
+                  notif.triggeredBy.username
+                } isimli kullanıcı şu yorumunuzu yanıtladı: "${notif.comment.content.substring(
+                  0,
+                  30
+                )}..."`
+              );
             break;
           case "COMMENT":
-            messageArray.push(
-              `${notif.triggeredBy.username} isimli kullanıcı "${notif.post.title}" paylaşımınıza bir yorum yaptı.`
-            );
+            if (notif.post)
+              messageArray.push(
+                `${notif.triggeredBy.username} isimli kullanıcı "${notif.post.title}" paylaşımınıza bir yorum yaptı.`
+              );
             break;
           case "UPVOTEPOST":
-            messageArray.push(
-              `${notif.triggeredBy.username} isimli kullanıcı "${notif.post.title}" paylaşımınızı beğendi.`
-            );
+            if (notif.post)
+              messageArray.push(
+                `${notif.triggeredBy.username} isimli kullanıcı "${notif.post.title}" paylaşımınızı beğendi.`
+              );
             break;
           case "UPVOTECOMMENT":
-            messageArray.push(
-              `${
-                notif.triggeredBy.username
-              } isimli kullanıcı şu yorumunuzu beğendi: "${notif.comment.content.substring(
-                0,
-                30
-              )}"`
-            );
+            if (notif.comment)
+              messageArray.push(
+                `${
+                  notif.triggeredBy.username
+                } isimli kullanıcı şu yorumunuzu beğendi: "${notif.comment.content.substring(
+                  0,
+                  30
+                )}"`
+              );
             break;
         }
         setProcessedNotifications(messageArray);
@@ -99,6 +111,10 @@ export const NotificationDropdown: FC<Props> = (props) => {
       </fetcher.Form>
 
       <MenuContent sideOffset={10}>
+        <MenuItem onClick={() => handleRead()}>
+          Hepsini okundu olarak işaretle
+        </MenuItem>
+        <DropdownMenuSeparator />
         {processedNotifications &&
           fetcher.data?.notifications.map(
             (notif: MyNotification, index: number) => (
@@ -107,7 +123,16 @@ export const NotificationDropdown: FC<Props> = (props) => {
                   to={notif.url}
                   state={{ targetHash: notif.comment?.id }}
                 >
-                  <MenuItem>{processedNotifications[index]}</MenuItem>
+                  <MenuItem
+                    className={!notif.read ? "unread" : ""}
+                    css={{
+                      "&.unread:not(:hover)": {
+                        backgroundColor: "$amber4",
+                      },
+                    }}
+                  >
+                    {processedNotifications[index]}
+                  </MenuItem>
                 </MenuLink>
               </Fragment>
             )

--- a/apps/pano/app/features/notification-dropdown/NotificationDropdown.tsx
+++ b/apps/pano/app/features/notification-dropdown/NotificationDropdown.tsx
@@ -8,7 +8,7 @@ import {
   Link,
   styled,
 } from "@kampus/ui";
-import { PlusIcon } from "@radix-ui/react-icons";
+import { BellIcon, PlusIcon } from "@radix-ui/react-icons";
 import { useFetcher } from "@remix-run/react";
 import { FC, Fragment, useEffect, useState } from "react";
 import { MyNotification } from "~/models/notification.server";
@@ -27,6 +27,22 @@ const MenuLink = styled(Link, {
   textDecoration: "none",
 });
 
+const MenuIconButton = styled(IconButton, {
+  padding: 0,
+  borderRadius: "50%",
+  position: "relative",
+});
+
+const MenuIconChip = styled("div", {
+  borderRadius: "50%",
+  width: "$2",
+  height: "$2",
+  backgroundColor: "$amber9",
+  position: "absolute",
+  top: "0",
+  right: "0",
+});
+
 interface Props {}
 
 export const NotificationDropdown: FC<Props> = (props) => {
@@ -34,6 +50,7 @@ export const NotificationDropdown: FC<Props> = (props) => {
   const [processedNotifications, setProcessedNotifications] = useState<
     string[]
   >([]);
+  const [haveUnread, setHaveUnread] = useState(false);
 
   const handleReadAll = () => {
     fetcher.submit(
@@ -57,8 +74,10 @@ export const NotificationDropdown: FC<Props> = (props) => {
 
   useEffect(() => {
     const messageArray: string[] = [];
-    if (fetcher.data)
+    setHaveUnread(false);
+    if (fetcher.data) {
       (fetcher.data.notifications as MyNotification[])?.forEach((notif) => {
+        // process fetcher data into meaningful messages
         switch (notif.type) {
           case "REPLY":
             if (notif.comment)
@@ -95,24 +114,21 @@ export const NotificationDropdown: FC<Props> = (props) => {
               );
             break;
         }
-        setProcessedNotifications(messageArray);
+
+        // check if any unread
+        if (!notif.read) setHaveUnread(true);
       });
+      setProcessedNotifications(messageArray);
+    }
   }, [fetcher.data]);
 
   return (
     <DropdownMenu>
       <DropdownMenuTrigger asChild>
-        <IconButton
-          color="transparent"
-          css={{
-            padding: 0,
-            borderRadius: "50%",
-            width: "auto",
-            height: "auto",
-          }}
-        >
-          <PlusIcon />
-        </IconButton>
+        <MenuIconButton>
+          {haveUnread && <MenuIconChip />}
+          <BellIcon />
+        </MenuIconButton>
       </DropdownMenuTrigger>
 
       <MenuContent sideOffset={10}>

--- a/apps/pano/app/features/notification-dropdown/NotificationDropdown.tsx
+++ b/apps/pano/app/features/notification-dropdown/NotificationDropdown.tsx
@@ -106,7 +106,6 @@ export const NotificationDropdown: FC<Props> = (props) => {
                 <MenuLink to={notif.url}>
                   <MenuItem>{processedNotifications[index]}</MenuItem>
                 </MenuLink>
-                <DropdownMenuSeparator />
               </Fragment>
             )
           )}

--- a/apps/pano/app/features/notification-dropdown/NotificationDropdown.tsx
+++ b/apps/pano/app/features/notification-dropdown/NotificationDropdown.tsx
@@ -17,8 +17,13 @@ import { useFetcher } from "@remix-run/react";
 import { FC, Fragment, useEffect, useState } from "react";
 import { MyNotification } from "~/models/notification.server";
 
+const MenuContent = styled(DropdownMenuContent, {
+  maxWidth: "$9",
+});
+
 const MenuItem = styled(DropdownMenuItem, {
-  width: "auto",
+  height: "auto",
+  padding: "$2",
   cursor: "pointer",
 });
 
@@ -98,7 +103,7 @@ export const NotificationDropdown: FC<Props> = (props) => {
         </DropdownMenuTrigger>
       </fetcher.Form>
 
-      <DropdownMenuContent sideOffset={5}>
+      <MenuContent sideOffset={10}>
         {processedNotifications &&
           fetcher.data?.notifications.map(
             (notif: MyNotification, index: number) => (
@@ -112,7 +117,7 @@ export const NotificationDropdown: FC<Props> = (props) => {
               </Fragment>
             )
           )}
-      </DropdownMenuContent>
+      </MenuContent>
     </DropdownMenu>
   );
 };

--- a/apps/pano/app/features/notification-dropdown/NotificationDropdown.tsx
+++ b/apps/pano/app/features/notification-dropdown/NotificationDropdown.tsx
@@ -103,7 +103,10 @@ export const NotificationDropdown: FC<Props> = (props) => {
           fetcher.data?.notifications.map(
             (notif: MyNotification, index: number) => (
               <Fragment key={notif.id}>
-                <MenuLink to={notif.url}>
+                <MenuLink
+                  to={notif.url}
+                  state={{ targetHash: notif.comment.id }}
+                >
                   <MenuItem>{processedNotifications[index]}</MenuItem>
                 </MenuLink>
               </Fragment>

--- a/apps/pano/app/features/notification-dropdown/NotificationDropdown.tsx
+++ b/apps/pano/app/features/notification-dropdown/NotificationDropdown.tsx
@@ -137,7 +137,7 @@ export const NotificationDropdown: FC<Props> = (props) => {
           Hepsini okundu olarak işaretle
         </MenuItem>
         <DropdownMenuSeparator />
-        {processedNotifications &&
+        {processedNotifications.length > 0 ? (
           fetcher.data?.notifications?.map(
             (notif: MyNotification, index: number) => (
               <Fragment key={notif.id}>
@@ -161,7 +161,10 @@ export const NotificationDropdown: FC<Props> = (props) => {
                 </MenuLink>
               </Fragment>
             )
-          )}
+          )
+        ) : (
+          <MenuItem>Görülen o ki burası boş.</MenuItem>
+        )}
       </MenuContent>
     </DropdownMenu>
   );

--- a/apps/pano/app/features/notification-dropdown/NotificationDropdown.tsx
+++ b/apps/pano/app/features/notification-dropdown/NotificationDropdown.tsx
@@ -14,7 +14,8 @@ import {
 import { Notification, User } from "@prisma/client";
 import { PlusIcon } from "@radix-ui/react-icons";
 import { useFetcher } from "@remix-run/react";
-import { FC, Fragment, useEffect } from "react";
+import { FC, Fragment, useEffect, useState } from "react";
+import { MyNotification } from "~/models/notification.server";
 
 const MenuItem = styled(DropdownMenuItem, {
   width: "auto",
@@ -29,12 +30,53 @@ interface Props {}
 
 export const NotificationDropdown: FC<Props> = (props) => {
   const fetcher = useFetcher();
+  const [processedNotifications, setProcessedNotifications] = useState<
+    string[]
+  >([]);
 
   useEffect(() => {
     if (fetcher.state === "idle" && fetcher.data == null) {
       fetcher.load("/notifications/my-notifications");
     }
   }, [fetcher]);
+
+  useEffect(() => {
+    const messageArray: string[] = [];
+    if (fetcher.data)
+      (fetcher.data.notifications as MyNotification[]).forEach((notif) => {
+        switch (notif.type) {
+          case "REPLY":
+            messageArray.push(
+              `${
+                notif.triggeredBy.username
+              } isimli kullanıcı şu yorumunuzu yanıtladı: "${notif.comment.content.slice(
+                30
+              )}..."`
+            );
+            break;
+          case "COMMENT":
+            messageArray.push(
+              `${notif.triggeredBy.username} isimli kullanıcı "${notif.post.title}" paylaşımınıza bir yorum yaptı.`
+            );
+            break;
+          case "UPVOTECOMMENT":
+            messageArray.push(
+              `${notif.triggeredBy.username} isimli kullanıcı "${notif.post.title}" paylaşımınızı beğendi.`
+            );
+            break;
+          case "UPVOTEPOST":
+            messageArray.push(
+              `${
+                notif.triggeredBy.username
+              } isimli kullanıcı şu yorumunuzu beğendi: "${notif.comment.content.slice(
+                30
+              )}"`
+            );
+            break;
+        }
+        setProcessedNotifications(messageArray);
+      });
+  }, [fetcher.data]);
 
   return (
     <DropdownMenu>
@@ -55,14 +97,17 @@ export const NotificationDropdown: FC<Props> = (props) => {
       </fetcher.Form>
 
       <DropdownMenuContent sideOffset={5}>
-        {fetcher.data?.notifications.map((notif: Notification) => (
-          <Fragment key={notif.id}>
-            <MenuItem>{notif.type}</MenuItem>
-            <DropdownMenuSeparator />
-          </Fragment>
-        ))}
-        <DropdownMenuSeparator />
-        <DropdownMenuArrow offset={12} />
+        {processedNotifications &&
+          fetcher.data?.notifications.map(
+            (notif: MyNotification, index: number) => (
+              <Fragment key={notif.id}>
+                <MenuLink to={notif.url}>
+                  <MenuItem>{processedNotifications[index]}</MenuItem>
+                </MenuLink>
+                <DropdownMenuSeparator />
+              </Fragment>
+            )
+          )}
       </DropdownMenuContent>
     </DropdownMenu>
   );

--- a/apps/pano/app/features/notification-dropdown/NotificationDropdown.tsx
+++ b/apps/pano/app/features/notification-dropdown/NotificationDropdown.tsx
@@ -25,41 +25,34 @@ const MenuLink = styled(Link, {
   textDecoration: "none",
 });
 
-interface Props {
-  user: User;
-}
+interface Props {}
 
 export const NotificationDropdown: FC<Props> = (props) => {
   const fetcher = useFetcher();
-
-  useEffect(() => {
-    console.log(fetcher);
-    if (fetcher.state === "idle" && fetcher.data == null) {
-      fetcher.load("/notifications/my-notifications");
-    }
-  }, [fetcher]);
 
   useEffect(() => {
     console.log(fetcher.data);
   }, [fetcher.data]);
 
   return (
-    <DropdownMenu>
-      <fetcher.Form method="get" action="/notification/my-notifications">
-        <DropdownMenuTrigger asChild>
-          <IconButton
-            color="transparent"
-            css={{
-              padding: 0,
-              borderRadius: "50%",
-              width: "auto",
-              height: "auto",
-            }}
-          >
-            <PlusIcon />
-          </IconButton>
-        </DropdownMenuTrigger>
-      </fetcher.Form>
+    <DropdownMenu
+      onOpenChange={(open) => {
+        if (open) fetcher.load("/notifications/my-notifications");
+      }}
+    >
+      <DropdownMenuTrigger asChild>
+        <IconButton
+          color="transparent"
+          css={{
+            padding: 0,
+            borderRadius: "50%",
+            width: "auto",
+            height: "auto",
+          }}
+        >
+          <PlusIcon />
+        </IconButton>
+      </DropdownMenuTrigger>
 
       <DropdownMenuContent sideOffset={5}>
         {fetcher.data?.notifications.map((notif: Notification) => (

--- a/apps/pano/app/features/notification-dropdown/NotificationDropdown.tsx
+++ b/apps/pano/app/features/notification-dropdown/NotificationDropdown.tsx
@@ -49,7 +49,8 @@ export const NotificationDropdown: FC<Props> = (props) => {
             messageArray.push(
               `${
                 notif.triggeredBy.username
-              } isimli kullanıcı şu yorumunuzu yanıtladı: "${notif.comment.content.slice(
+              } isimli kullanıcı şu yorumunuzu yanıtladı: "${notif.comment.content.substring(
+                0,
                 30
               )}..."`
             );
@@ -68,7 +69,8 @@ export const NotificationDropdown: FC<Props> = (props) => {
             messageArray.push(
               `${
                 notif.triggeredBy.username
-              } isimli kullanıcı şu yorumunuzu beğendi: "${notif.comment.content.slice(
+              } isimli kullanıcı şu yorumunuzu beğendi: "${notif.comment.content.substring(
+                0,
                 30
               )}"`
             );

--- a/apps/pano/app/features/notification-dropdown/NotificationDropdown.tsx
+++ b/apps/pano/app/features/notification-dropdown/NotificationDropdown.tsx
@@ -31,28 +31,28 @@ export const NotificationDropdown: FC<Props> = (props) => {
   const fetcher = useFetcher();
 
   useEffect(() => {
-    console.log(fetcher.data);
-  }, [fetcher.data]);
+    if (fetcher.state === "idle" && fetcher.data == null) {
+      fetcher.load("/notifications/my-notifications");
+    }
+  }, [fetcher]);
 
   return (
-    <DropdownMenu
-      onOpenChange={(open) => {
-        if (open) fetcher.load("/notifications/my-notifications");
-      }}
-    >
-      <DropdownMenuTrigger asChild>
-        <IconButton
-          color="transparent"
-          css={{
-            padding: 0,
-            borderRadius: "50%",
-            width: "auto",
-            height: "auto",
-          }}
-        >
-          <PlusIcon />
-        </IconButton>
-      </DropdownMenuTrigger>
+    <DropdownMenu>
+      <fetcher.Form method="get" action="/notification/my-notifications">
+        <DropdownMenuTrigger asChild>
+          <IconButton
+            color="transparent"
+            css={{
+              padding: 0,
+              borderRadius: "50%",
+              width: "auto",
+              height: "auto",
+            }}
+          >
+            <PlusIcon />
+          </IconButton>
+        </DropdownMenuTrigger>
+      </fetcher.Form>
 
       <DropdownMenuContent sideOffset={5}>
         {fetcher.data?.notifications.map((notif: Notification) => (

--- a/apps/pano/app/features/notification-dropdown/NotificationDropdown.tsx
+++ b/apps/pano/app/features/notification-dropdown/NotificationDropdown.tsx
@@ -8,10 +8,11 @@ import {
   Link,
   styled,
 } from "@kampus/ui";
-import { BellIcon, PlusIcon } from "@radix-ui/react-icons";
+import { BellIcon } from "@radix-ui/react-icons";
 import { useFetcher } from "@remix-run/react";
-import { FC, Fragment, useEffect, useState } from "react";
-import { MyNotification } from "~/models/notification.server";
+import type { FC } from "react";
+import { Fragment, useEffect, useState } from "react";
+import type { MyNotification } from "~/models/notification.server";
 
 const MenuContent = styled(DropdownMenuContent, {
   maxWidth: "$9",

--- a/apps/pano/app/features/notification-dropdown/NotificationDropdown.tsx
+++ b/apps/pano/app/features/notification-dropdown/NotificationDropdown.tsx
@@ -35,10 +35,17 @@ export const NotificationDropdown: FC<Props> = (props) => {
     string[]
   >([]);
 
-  const handleRead = () => {
+  const handleReadAll = () => {
     fetcher.submit(
       {},
-      { method: "post", action: "/notifications/my-notifications" }
+      { method: "put", action: "/notifications/my-notifications" }
+    );
+  };
+
+  const handleReadSingle = (id: string) => {
+    fetcher.submit(
+      {},
+      { method: "put", action: `/notifications/my-notifications/${id}` }
     );
   };
 
@@ -51,7 +58,7 @@ export const NotificationDropdown: FC<Props> = (props) => {
   useEffect(() => {
     const messageArray: string[] = [];
     if (fetcher.data)
-      (fetcher.data.notifications as MyNotification[]).forEach((notif) => {
+      (fetcher.data.notifications as MyNotification[])?.forEach((notif) => {
         switch (notif.type) {
           case "REPLY":
             if (notif.comment)
@@ -94,33 +101,34 @@ export const NotificationDropdown: FC<Props> = (props) => {
 
   return (
     <DropdownMenu>
-      <fetcher.Form method="get" action="/notification/my-notifications">
-        <DropdownMenuTrigger asChild>
-          <IconButton
-            color="transparent"
-            css={{
-              padding: 0,
-              borderRadius: "50%",
-              width: "auto",
-              height: "auto",
-            }}
-          >
-            <PlusIcon />
-          </IconButton>
-        </DropdownMenuTrigger>
-      </fetcher.Form>
+      <DropdownMenuTrigger asChild>
+        <IconButton
+          color="transparent"
+          css={{
+            padding: 0,
+            borderRadius: "50%",
+            width: "auto",
+            height: "auto",
+          }}
+        >
+          <PlusIcon />
+        </IconButton>
+      </DropdownMenuTrigger>
 
       <MenuContent sideOffset={10}>
-        <MenuItem onClick={() => handleRead()}>
+        <MenuItem onClick={() => handleReadAll()}>
           Hepsini okundu olarak işaretle
         </MenuItem>
         <DropdownMenuSeparator />
         {processedNotifications &&
-          fetcher.data?.notifications.map(
+          fetcher.data?.notifications?.map(
             (notif: MyNotification, index: number) => (
               <Fragment key={notif.id}>
                 <MenuLink
                   to={notif.url}
+                  onClick={() => {
+                    handleReadSingle(notif.id);
+                  }}
                   state={{ targetHash: notif.comment?.id }}
                 >
                   <MenuItem

--- a/apps/pano/app/features/topnav/Topnav.tsx
+++ b/apps/pano/app/features/topnav/Topnav.tsx
@@ -11,6 +11,7 @@ import { PlusIcon } from "@radix-ui/react-icons";
 import { useFetcher } from "@remix-run/react";
 import type { FC } from "react";
 import { SearchInput } from "./SearchInput";
+import { NotificationDropdown } from "../notification-dropdown/NotificationDropdown";
 import { useUserContext } from "~/features/auth/user-context";
 import { UserDropdown } from "~/features/user-dropdown/UserDropdown";
 
@@ -43,6 +44,7 @@ export const Topnav: FC = () => {
                   />
                   <ThemeToggle />
                 </fetcher.Form>
+                <NotificationDropdown user={user} />
                 <UserDropdown login={user.username} />
               </>
             ) : (

--- a/apps/pano/app/features/topnav/Topnav.tsx
+++ b/apps/pano/app/features/topnav/Topnav.tsx
@@ -10,7 +10,6 @@ import {
 import { PlusIcon } from "@radix-ui/react-icons";
 import { useFetcher } from "@remix-run/react";
 import type { FC } from "react";
-import { useEffect } from "react";
 import { SearchInput } from "./SearchInput";
 import { NotificationDropdown } from "../notification-dropdown/NotificationDropdown";
 import { useUserContext } from "~/features/auth/user-context";

--- a/apps/pano/app/features/topnav/Topnav.tsx
+++ b/apps/pano/app/features/topnav/Topnav.tsx
@@ -10,6 +10,7 @@ import {
 import { PlusIcon } from "@radix-ui/react-icons";
 import { useFetcher } from "@remix-run/react";
 import type { FC } from "react";
+import { useEffect } from "react";
 import { SearchInput } from "./SearchInput";
 import { NotificationDropdown } from "../notification-dropdown/NotificationDropdown";
 import { useUserContext } from "~/features/auth/user-context";
@@ -44,7 +45,7 @@ export const Topnav: FC = () => {
                   />
                   <ThemeToggle />
                 </fetcher.Form>
-                <NotificationDropdown user={user} />
+                <NotificationDropdown />
                 <UserDropdown login={user.username} />
               </>
             ) : (

--- a/apps/pano/app/models/notification.server.ts
+++ b/apps/pano/app/models/notification.server.ts
@@ -1,4 +1,4 @@
-import { Notification, Prisma } from "@prisma/client";
+import type { Notification } from "@prisma/client";
 import { prisma } from "~/db.server";
 import { getExternalCommentURL, getExternalPostURL } from "~/utils";
 import { env } from "~/utils/env.server";

--- a/apps/pano/app/models/notification.server.ts
+++ b/apps/pano/app/models/notification.server.ts
@@ -16,9 +16,7 @@ export type MyNotification = Pick<
 
 export type NotificationDeleteReason =
   | "UPVOTE_REMOVED_ON_POST"
-  | "UPVOTE_REMOVED_ON_COMMENT"
-  | "POST_DELETED"
-  | "COMMENT_DELETED";
+  | "UPVOTE_REMOVED_ON_COMMENT";
 
 export const getMyNotifications = (userID: string, page: number) => {
   return prisma.notification.findMany({

--- a/apps/pano/app/models/notification.server.ts
+++ b/apps/pano/app/models/notification.server.ts
@@ -11,7 +11,7 @@ export type MyNotification = Pick<
 > & {
   triggeredBy: { username: string };
   post: { title: string };
-  comment: { content: string };
+  comment: { content: string; id: string };
 };
 
 export type NotificationDeleteReason =
@@ -40,6 +40,7 @@ export const getMyNotifications = (userID: string, page: number) => {
       },
       comment: {
         select: {
+          id: true,
           content: true,
         },
       },

--- a/apps/pano/app/models/notification.server.ts
+++ b/apps/pano/app/models/notification.server.ts
@@ -55,7 +55,7 @@ export const getMyNotifications = (userID: string, page: number) => {
   });
 };
 
-export const readMyNotifications = async (userID: string, page: number) => {
+export const readMyNotifications = async (userID: string) => {
   await prisma.notification.updateMany({
     where: {
       notifiesUserID: userID,
@@ -66,7 +66,20 @@ export const readMyNotifications = async (userID: string, page: number) => {
     },
   });
 
-  return await getMyNotifications(userID, page);
+  return await getMyNotifications(userID, 1);
+};
+
+export const readMyNotification = async (userID: string, id: string) => {
+  await prisma.notification.update({
+    where: {
+      id,
+    },
+    data: {
+      read: true,
+    },
+  });
+
+  return await getMyNotifications(userID, 1);
 };
 
 export const createNotification = async (

--- a/apps/pano/app/models/notification.server.ts
+++ b/apps/pano/app/models/notification.server.ts
@@ -52,13 +52,16 @@ export const createNotification = async (
     );
   }
 
-  return prisma.notification.create({
-    data: {
-      notifiesUserID: sourceData.userID,
-      triggeredByUserID: triggerUserID,
-      type,
-      postID,
-      commentID,
-    },
-  });
+  // Can't notify if self
+  if (sourceData.userID !== triggerUserID)
+    return prisma.notification.create({
+      data: {
+        notifiesUserID: sourceData.userID,
+        triggeredByUserID: triggerUserID,
+        type,
+        postID,
+        commentID,
+      },
+    });
+  return null;
 };

--- a/apps/pano/app/models/notification.server.ts
+++ b/apps/pano/app/models/notification.server.ts
@@ -10,8 +10,8 @@ export type MyNotification = Pick<
   "id" | "url" | "type" | "read" | "createdAt"
 > & {
   triggeredBy: { username: string };
-  post: { title: string };
-  comment: { content: string; id: string };
+  post: { title: string } | null;
+  comment: { content: string; id: string } | null;
 };
 
 export type NotificationDeleteReason =
@@ -53,6 +53,20 @@ export const getMyNotifications = (userID: string, page: number) => {
     },
     take: 10 * page,
   });
+};
+
+export const readMyNotifications = async (userID: string, page: number) => {
+  await prisma.notification.updateMany({
+    where: {
+      notifiesUserID: userID,
+      read: false,
+    },
+    data: {
+      read: true,
+    },
+  });
+
+  return await getMyNotifications(userID, page);
 };
 
 export const createNotification = async (

--- a/apps/pano/app/models/notification.server.ts
+++ b/apps/pano/app/models/notification.server.ts
@@ -9,7 +9,7 @@ export type NotificationDeleteReason =
   | "POST_DELETED"
   | "COMMENT_DELETED";
 
-export const getMyNotifications = (userID: string) => {
+export const getMyNotifications = (userID: string, page: number) => {
   return prisma.notification.findMany({
     where: {
       notifiesUserID: userID,
@@ -17,6 +17,7 @@ export const getMyNotifications = (userID: string) => {
     orderBy: {
       createdAt: "desc",
     },
+    take: 10 * page,
   });
 };
 

--- a/apps/pano/app/models/notification.server.ts
+++ b/apps/pano/app/models/notification.server.ts
@@ -1,0 +1,64 @@
+import { Prisma } from "@prisma/client";
+import { prisma } from "~/db.server";
+
+export type NotificationType =
+  | "UPVOTECOMMENT"
+  | "UPVOTEPOST"
+  | "COMMENT"
+  | "REPLY";
+
+export const getMyNotifications = (userID: string) => {
+  return prisma.notification.findMany({
+    where: {
+      notifiesUserID: userID,
+    },
+    orderBy: {
+      createdAt: "desc",
+    },
+  });
+};
+
+export const createNotification = async (
+  type: NotificationType,
+  triggerUserID: string,
+  postID: string | null,
+  commentID: string | null
+) => {
+  let sourceData;
+
+  if (postID) {
+    sourceData = await prisma.post.findFirst({
+      select: {
+        userID: true,
+      },
+      where: {
+        id: postID,
+      },
+    });
+  } else if (commentID) {
+    sourceData = await prisma.comment.findFirst({
+      select: {
+        userID: true,
+      },
+      where: {
+        id: commentID,
+      },
+    });
+  }
+
+  if (sourceData == undefined) {
+    throw new Error(
+      "Both postID and commentID could not be null at the same time"
+    );
+  }
+
+  return prisma.notification.create({
+    data: {
+      notifiesUserID: sourceData.userID,
+      triggeredByUserID: triggerUserID,
+      type,
+      postID,
+      commentID,
+    },
+  });
+};

--- a/apps/pano/app/routes/commentUpvote.tsx
+++ b/apps/pano/app/routes/commentUpvote.tsx
@@ -1,7 +1,10 @@
 import type { ActionFunction } from "@remix-run/node";
 import invariant from "tiny-invariant";
 import { createUpvote, deleteUpvote } from "~/models/comment.server";
-import { createNotification } from "~/models/notification.server";
+import {
+  createNotification,
+  deleteNotifications,
+} from "~/models/notification.server";
 
 export const action: ActionFunction = async ({ request }) => {
   const formData = await request.formData();
@@ -31,6 +34,11 @@ export const action: ActionFunction = async ({ request }) => {
     case "delete":
       try {
         await deleteUpvote(input.commentID, input.userID);
+        await deleteNotifications(
+          "UPVOTE_REMOVED_ON_COMMENT",
+          input.userID,
+          input.commentID
+        );
       } catch (e) {
         return {
           status: 500,

--- a/apps/pano/app/routes/commentUpvote.tsx
+++ b/apps/pano/app/routes/commentUpvote.tsx
@@ -1,6 +1,7 @@
 import type { ActionFunction } from "@remix-run/node";
 import invariant from "tiny-invariant";
 import { createUpvote, deleteUpvote } from "~/models/comment.server";
+import { createNotification } from "~/models/notification.server";
 
 export const action: ActionFunction = async ({ request }) => {
   const formData = await request.formData();
@@ -14,6 +15,12 @@ export const action: ActionFunction = async ({ request }) => {
     case "create":
       try {
         await createUpvote(input.commentID, input.userID);
+        await createNotification(
+          "UPVOTECOMMENT",
+          input.userID,
+          null,
+          input.commentID
+        );
       } catch (e) {
         return {
           status: 500,

--- a/apps/pano/app/routes/notifications/my-notifications.tsx
+++ b/apps/pano/app/routes/notifications/my-notifications.tsx
@@ -1,9 +1,7 @@
 import { Notification } from "@prisma/client";
 import type { LoaderFunction } from "@remix-run/node";
 import { json } from "@remix-run/node";
-import { useLoaderData } from "@remix-run/react";
 import { requireUser } from "~/authenticator.server";
-import { NotificationDropdown } from "~/features/notification-dropdown/NotificationDropdown";
 import { getMyNotifications } from "~/models/notification.server";
 
 type LoaderData = {
@@ -11,7 +9,11 @@ type LoaderData = {
 };
 
 export const loader: LoaderFunction = async ({ request }) => {
-  const user = await requireUser(request);
-  const notifications = await getMyNotifications(user.id);
-  return json<LoaderData>({ notifications });
+  try {
+    const user = await requireUser(request);
+    const notifications = await getMyNotifications(user.id);
+    return json<LoaderData>({ notifications });
+  } catch (e) {
+    return json<LoaderData>({ notifications: [] });
+  }
 };

--- a/apps/pano/app/routes/notifications/my-notifications.tsx
+++ b/apps/pano/app/routes/notifications/my-notifications.tsx
@@ -1,4 +1,3 @@
-import { Notification } from "@prisma/client";
 import type { ActionFunction, LoaderFunction } from "@remix-run/node";
 import { json } from "@remix-run/node";
 import { requireUser } from "~/authenticator.server";
@@ -9,6 +8,10 @@ import {
 import { getMyNotifications } from "~/models/notification.server";
 
 type LoaderData = {
+  notifications: MyNotification[];
+};
+
+type ActionData = {
   notifications: MyNotification[];
 };
 
@@ -25,9 +28,9 @@ export const loader: LoaderFunction = async ({ request }) => {
 export const action: ActionFunction = async ({ request }) => {
   try {
     const user = await requireUser(request);
-    const notifications = await readMyNotifications(user.id, 1);
-    return json<LoaderData>({ notifications });
+    const notifications = await readMyNotifications(user.id);
+    return json<ActionData>({ notifications });
   } catch (e) {
-    return json<LoaderData>({ notifications: [] });
+    return json<ActionData>({ notifications: [] });
   }
 };

--- a/apps/pano/app/routes/notifications/my-notifications.tsx
+++ b/apps/pano/app/routes/notifications/my-notifications.tsx
@@ -1,0 +1,17 @@
+import { Notification } from "@prisma/client";
+import type { LoaderFunction } from "@remix-run/node";
+import { json } from "@remix-run/node";
+import { useLoaderData } from "@remix-run/react";
+import { requireUser } from "~/authenticator.server";
+import { NotificationDropdown } from "~/features/notification-dropdown/NotificationDropdown";
+import { getMyNotifications } from "~/models/notification.server";
+
+type LoaderData = {
+  notifications: Notification[];
+};
+
+export const loader: LoaderFunction = async ({ request }) => {
+  const user = await requireUser(request);
+  const notifications = await getMyNotifications(user.id);
+  return json<LoaderData>({ notifications });
+};

--- a/apps/pano/app/routes/notifications/my-notifications.tsx
+++ b/apps/pano/app/routes/notifications/my-notifications.tsx
@@ -2,8 +2,10 @@ import type { ActionFunction, LoaderFunction } from "@remix-run/node";
 import { json } from "@remix-run/node";
 import { requireUser } from "~/authenticator.server";
 import type { MyNotification } from "~/models/notification.server";
-import { readMyNotifications } from "~/models/notification.server";
-import { getMyNotifications } from "~/models/notification.server";
+import {
+  getMyNotifications,
+  readMyNotifications,
+} from "~/models/notification.server";
 
 type LoaderData = {
   notifications: MyNotification[];

--- a/apps/pano/app/routes/notifications/my-notifications.tsx
+++ b/apps/pano/app/routes/notifications/my-notifications.tsx
@@ -1,10 +1,8 @@
 import type { ActionFunction, LoaderFunction } from "@remix-run/node";
 import { json } from "@remix-run/node";
 import { requireUser } from "~/authenticator.server";
-import {
-  MyNotification,
-  readMyNotifications,
-} from "~/models/notification.server";
+import type { MyNotification } from "~/models/notification.server";
+import { readMyNotifications } from "~/models/notification.server";
 import { getMyNotifications } from "~/models/notification.server";
 
 type LoaderData = {

--- a/apps/pano/app/routes/notifications/my-notifications.tsx
+++ b/apps/pano/app/routes/notifications/my-notifications.tsx
@@ -11,7 +11,7 @@ type LoaderData = {
 export const loader: LoaderFunction = async ({ request }) => {
   try {
     const user = await requireUser(request);
-    const notifications = await getMyNotifications(user.id);
+    const notifications = await getMyNotifications(user.id, 1);
     return json<LoaderData>({ notifications });
   } catch (e) {
     return json<LoaderData>({ notifications: [] });

--- a/apps/pano/app/routes/notifications/my-notifications.tsx
+++ b/apps/pano/app/routes/notifications/my-notifications.tsx
@@ -1,17 +1,31 @@
 import { Notification } from "@prisma/client";
-import type { LoaderFunction } from "@remix-run/node";
+import type { ActionFunction, LoaderFunction } from "@remix-run/node";
 import { json } from "@remix-run/node";
 import { requireUser } from "~/authenticator.server";
+import {
+  MyNotification,
+  readMyNotifications,
+} from "~/models/notification.server";
 import { getMyNotifications } from "~/models/notification.server";
 
 type LoaderData = {
-  notifications: Notification[];
+  notifications: MyNotification[];
 };
 
 export const loader: LoaderFunction = async ({ request }) => {
   try {
     const user = await requireUser(request);
     const notifications = await getMyNotifications(user.id, 1);
+    return json<LoaderData>({ notifications });
+  } catch (e) {
+    return json<LoaderData>({ notifications: [] });
+  }
+};
+
+export const action: ActionFunction = async ({ request }) => {
+  try {
+    const user = await requireUser(request);
+    const notifications = await readMyNotifications(user.id, 1);
     return json<LoaderData>({ notifications });
   } catch (e) {
     return json<LoaderData>({ notifications: [] });

--- a/apps/pano/app/routes/notifications/my-notifications/$id.tsx
+++ b/apps/pano/app/routes/notifications/my-notifications/$id.tsx
@@ -1,0 +1,20 @@
+import type { ActionFunction, LoaderFunction } from "@remix-run/node";
+import { json } from "@remix-run/node";
+import { requireUser } from "~/authenticator.server";
+import type { MyNotification } from "~/models/notification.server";
+import { readMyNotification } from "~/models/notification.server";
+
+export type ActionData = {
+  notifications: MyNotification[];
+};
+
+export const action: ActionFunction = async ({ request, params }) => {
+  if (!params.id) return null;
+  try {
+    const user = await requireUser(request);
+    const notifications = await readMyNotification(user.id, params.id);
+    return json<ActionData>({ notifications });
+  } catch (e) {
+    return json<ActionData>({ notifications: [] });
+  }
+};

--- a/apps/pano/app/routes/notifications/my-notifications/$id.tsx
+++ b/apps/pano/app/routes/notifications/my-notifications/$id.tsx
@@ -1,4 +1,4 @@
-import type { ActionFunction, LoaderFunction } from "@remix-run/node";
+import type { ActionFunction } from "@remix-run/node";
 import { json } from "@remix-run/node";
 import { requireUser } from "~/authenticator.server";
 import type { MyNotification } from "~/models/notification.server";

--- a/apps/pano/app/routes/posts/$slug.$id.tsx
+++ b/apps/pano/app/routes/posts/$slug.$id.tsx
@@ -30,6 +30,7 @@ import { CommentItem } from "~/features/comment/Comment";
 import { PostItem } from "~/features/post/PostItem";
 import type { Comment } from "~/models/comment.server";
 import { createComment } from "~/models/comment.server";
+import { createNotification } from "~/models/notification.server";
 import type { Post } from "~/models/post.server";
 import { getPostBySlugAndId } from "~/models/post.server";
 import { validate } from "~/utils";
@@ -138,6 +139,9 @@ export const action: ActionFunction = async ({ request, params }) => {
 
   try {
     await createComment(content.toString(), params.id, user.id, commentID);
+    await createNotification("COMMENT", user.id, params.id, commentID);
+    if (commentID)
+      await createNotification("REPLY", user.id, params.id, commentID);
     return null;
   } catch {
     return json<ActionData>(

--- a/apps/pano/app/routes/posts/$slug.$id.tsx
+++ b/apps/pano/app/routes/posts/$slug.$id.tsx
@@ -140,8 +140,6 @@ export const action: ActionFunction = async ({ request, params }) => {
   try {
     await createComment(content.toString(), params.id, user.id, commentID);
     await createNotification("COMMENT", user.id, params.id, commentID);
-    if (commentID)
-      await createNotification("REPLY", user.id, params.id, commentID);
     return null;
   } catch {
     return json<ActionData>(

--- a/apps/pano/app/routes/upvote.tsx
+++ b/apps/pano/app/routes/upvote.tsx
@@ -1,6 +1,9 @@
 import type { ActionFunction } from "@remix-run/node";
 import invariant from "tiny-invariant";
-import { createNotification } from "~/models/notification.server";
+import {
+  createNotification,
+  deleteNotifications,
+} from "~/models/notification.server";
 import { createUpvote, deleteUpvote } from "~/models/post.server";
 
 export const action: ActionFunction = async ({ request }) => {
@@ -31,6 +34,11 @@ export const action: ActionFunction = async ({ request }) => {
     case "delete":
       try {
         await deleteUpvote(input.postID, input.userID);
+        await deleteNotifications(
+          "UPVOTE_REMOVED_ON_POST",
+          input.userID,
+          input.postID
+        );
       } catch (e) {
         return {
           status: 500,

--- a/apps/pano/app/routes/upvote.tsx
+++ b/apps/pano/app/routes/upvote.tsx
@@ -1,5 +1,6 @@
 import type { ActionFunction } from "@remix-run/node";
 import invariant from "tiny-invariant";
+import { createNotification } from "~/models/notification.server";
 import { createUpvote, deleteUpvote } from "~/models/post.server";
 
 export const action: ActionFunction = async ({ request }) => {
@@ -14,6 +15,12 @@ export const action: ActionFunction = async ({ request }) => {
     case "create":
       try {
         await createUpvote(input.postID, input.userID);
+        await createNotification(
+          "UPVOTEPOST",
+          input.userID,
+          input.postID,
+          null
+        );
       } catch (e) {
         return {
           status: 500,

--- a/apps/pano/prisma/migrations/20230406151334_add_notifications/migration.sql
+++ b/apps/pano/prisma/migrations/20230406151334_add_notifications/migration.sql
@@ -1,0 +1,27 @@
+-- CreateEnum
+CREATE TYPE "NotificationType" AS ENUM ('UPVOTE', 'COMMENT', 'REPLY');
+
+-- CreateTable
+CREATE TABLE "Notification" (
+    "id" TEXT NOT NULL,
+    "notifiesUserID" TEXT NOT NULL,
+    "triggeredByUserID" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "type" "NotificationType" NOT NULL,
+    "postID" TEXT,
+    "commentID" TEXT,
+
+    CONSTRAINT "Notification_pkey" PRIMARY KEY ("id")
+);
+
+-- AddForeignKey
+ALTER TABLE "Notification" ADD CONSTRAINT "Notification_notifiesUserID_fkey" FOREIGN KEY ("notifiesUserID") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Notification" ADD CONSTRAINT "Notification_triggeredByUserID_fkey" FOREIGN KEY ("triggeredByUserID") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Notification" ADD CONSTRAINT "Notification_postID_fkey" FOREIGN KEY ("postID") REFERENCES "Post"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Notification" ADD CONSTRAINT "Notification_commentID_fkey" FOREIGN KEY ("commentID") REFERENCES "Comment"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/apps/pano/prisma/migrations/20230406152607_add_read_status/migration.sql
+++ b/apps/pano/prisma/migrations/20230406152607_add_read_status/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "Notification" ADD COLUMN     "read" BOOLEAN NOT NULL DEFAULT false;

--- a/apps/pano/prisma/migrations/20230406155043_update_notification_types/migration.sql
+++ b/apps/pano/prisma/migrations/20230406155043_update_notification_types/migration.sql
@@ -1,0 +1,14 @@
+/*
+  Warnings:
+
+  - The values [UPVOTE] on the enum `NotificationType` will be removed. If these variants are still used in the database, this will fail.
+
+*/
+-- AlterEnum
+BEGIN;
+CREATE TYPE "NotificationType_new" AS ENUM ('UPVOTECOMMENT', 'UPVOTEPOST', 'COMMENT', 'REPLY');
+ALTER TABLE "Notification" ALTER COLUMN "type" TYPE "NotificationType_new" USING ("type"::text::"NotificationType_new");
+ALTER TYPE "NotificationType" RENAME TO "NotificationType_old";
+ALTER TYPE "NotificationType_new" RENAME TO "NotificationType";
+DROP TYPE "NotificationType_old";
+COMMIT;

--- a/apps/pano/prisma/migrations/20230407202239_add_notification_url/migration.sql
+++ b/apps/pano/prisma/migrations/20230407202239_add_notification_url/migration.sql
@@ -1,0 +1,8 @@
+/*
+  Warnings:
+
+  - Added the required column `url` to the `Notification` table without a default value. This is not possible if the table is not empty.
+
+*/
+-- AlterTable
+ALTER TABLE "Notification" ADD COLUMN     "url" TEXT NOT NULL;

--- a/apps/pano/prisma/schema.prisma
+++ b/apps/pano/prisma/schema.prisma
@@ -174,6 +174,7 @@ model Notification {
   comment Comment? @relation(fields: [commentID], references: [id], onDelete: Cascade, onUpdate: Cascade)
   commentID String?
   read Boolean @default(false)
+  url String
 }
 
 enum NotificationType {

--- a/apps/pano/prisma/schema.prisma
+++ b/apps/pano/prisma/schema.prisma
@@ -54,6 +54,8 @@ model Comment {
   comments Comment[]       @relation("CommentComments")
   upvotes  CommentUpvote[]
 
+  notifications Notification[]
+
   createdAt DateTime  @default(now())
   updatedAt DateTime  @updatedAt
   deletedAt DateTime?
@@ -76,6 +78,8 @@ model Post {
   createdAt DateTime  @default(now())
   updatedAt DateTime  @updatedAt
   deletedAt DateTime?
+
+  notifications Notification[]
 
   @@index([site])
 }
@@ -109,6 +113,8 @@ model User {
   deletedAt DateTime?
 
   preference UserPreference?
+  notifications Notification[] @relation("Notification")
+  notifies Notification[] @relation("Notifies")
 }
 
 enum Theme {
@@ -153,4 +159,24 @@ model SocialIdentity {
   createdAt DateTime  @default(now())
   updatedAt DateTime  @updatedAt
   deletedAt DateTime?
+}
+
+model Notification {
+  id String @id @default(cuid())
+  notifies User @relation(name: "Notification", fields: [notifiesUserID], references: [id], onDelete: Cascade, onUpdate: Cascade)
+  notifiesUserID String
+  triggeredBy User @relation(name: "Notifies", fields: [triggeredByUserID], references: [id], onDelete: Cascade, onUpdate: Cascade)
+  triggeredByUserID String
+  createdAt DateTime @default(now())
+  type NotificationType
+  post Post? @relation(fields: [postID], references: [id], onDelete: Cascade, onUpdate: Cascade)
+  postID String?
+  comment Comment? @relation(fields: [commentID], references: [id], onDelete: Cascade, onUpdate: Cascade)
+  commentID String?
+}
+
+enum NotificationType {
+  UPVOTE
+  COMMENT
+  REPLY
 }

--- a/apps/pano/prisma/schema.prisma
+++ b/apps/pano/prisma/schema.prisma
@@ -173,10 +173,12 @@ model Notification {
   postID String?
   comment Comment? @relation(fields: [commentID], references: [id], onDelete: Cascade, onUpdate: Cascade)
   commentID String?
+  read Boolean @default(false)
 }
 
 enum NotificationType {
-  UPVOTE
+  UPVOTECOMMENT
+  UPVOTEPOST
   COMMENT
   REPLY
 }

--- a/apps/pano/prisma/seed.ts
+++ b/apps/pano/prisma/seed.ts
@@ -5,6 +5,8 @@ import slugify from "slugify";
 const users = [
   { username: "admin", email: "admin@kamp.us", password: "123123" },
   { username: "testuser", email: "user1a@kamp.us", password: "123123123" },
+  { username: "berke", email: "andyanday33@gmail.com", password: "123123" },
+  { username: "anday", email: "nzl33_anday@hotmail.com", password: "123123" },
 ];
 const posts = [
   {

--- a/package-lock.json
+++ b/package-lock.json
@@ -44,6 +44,7 @@
         "remix-auth": "3.4.0",
         "remix-auth-discord": "1.2.1",
         "remix-auth-form": "1.3.0",
+        "remix-auth-github": "1.3.0",
         "remix-auth-otp": "2.2.0",
         "slugify": "1.6.5",
         "tiny-invariant": "1.3.1",


### PR DESCRIPTION
# Description

First iteration of the notification service for Pano, could be improved in further iterations.

### Functionalities:
- User gets a notification for an event (such as comment/upvote), on a post/comment that they own.
- An unread identifier will appear on top-right of the notifications icon if there are unread notifications.
- Notifications could be marked as read by clicking on them or clicking on "Hepsini okundu olarak işaretle" button.
- Unread identifier will disappear if all notifications are marked as read.

### There are 4 types of notifications: 
- "Upvote on comment": When user gets an upvote on their comment, they will get a notification linking to the comment which got upvoted alongside the username who upvoted the comment.
- "Upvote on post": When user gets an upvote on their post, they will get a notification linking to the post which got upvoted alongside the username who upvoted the post.
- "Comment on post": When user gets a comment on their post, they will get a notification linking to the comment under their post alongside the writer's username.
- "Reply to comment": When a user gets a reply to their comment, they will get a notification linking to the comment **that got replied**, alongside the replier's username.

### Constraints:
- If a user gets a reply to their comment under their own post, they will only get the notification for the reply.
- A user can not get notifications for their actions on their own posts/comments.
- Notification service could show only last 10 notifications for now.

### Example Scenario:
1. Let's have two actors with usernames "berke" and "anday", let's say "anday" creates a post and a comment,
![flow-1](https://user-images.githubusercontent.com/31995815/230725618-d70dc607-a49e-4af0-872a-df26693ebc09.png)

2. "berke" logs in and likes both the post and the comment.

3. "anday" is now able to see new notifications appear on the top right.
![flow-2](https://user-images.githubusercontent.com/31995815/230725675-1de69e8a-88b8-4c43-9378-b421ae9d7e35.png)

4. "anday" clicks to one of the notifications.
![flow-3](https://user-images.githubusercontent.com/31995815/230725687-f6aa4274-abaf-4ad3-9e6d-a17ea14c5ae5.png)

5. The link takes "anday" to the relevant comment, marking it.
![flow-4](https://user-images.githubusercontent.com/31995815/230725695-f4d5c91d-bf8d-41fc-9678-46d9e8fa8a2e.png)

6. For some reason "anday" deletes the post, all the notifications related to it gets deleted.
![flow-5](https://user-images.githubusercontent.com/31995815/230725864-eb0f1464-40c1-4cfb-9a83-e3ab619ba57b.png)


### Checklist

- [X] discord username: `bumshaqalaqa#2973`
- [X] Closes #360 
- [X] PR must be created for an issue from issues under "In progress" column from [our project board](https://github.com/orgs/kamp-us/projects/2/views/1).
- [X] A descriptive and understandable title: The PR title should clearly describe the nature and purpose of the changes. The PR title should be the first thing displayed when the PR is opened. And it should follow the semantic commit rules, and should include the app/package/service name in the title. For example, a title like "docs(@kampus-apps/pano): Add README.md" can be used.
- [X] Related file selection: Only relevant files should be touched and no other files should be affected.
- [X] I ran `npx turbo run` at the root of the repository, and build was successful.
- [X] I installed the npm packages using `npm install --save-exact <package>` so my package is pinned to a specific npm version. Leave empty if no package was installed. Leave empty if no package was installed with this PR.

### How were these changes tested?

Changes tested manually on different user scenarios.
