### PR TITLE
fix(apps/pano): light theme preference not retained after page refresh

### DIFF
--- a/apps/pano/app/root.tsx
+++ b/apps/pano/app/root.tsx
@@ -163,13 +163,13 @@ const Document = () => {
 };
 
 export default function App() {
-  const { user, isDevelopment, baseUrl, gaTrackingID } =
+  const { user, isDevelopment, baseUrl, gaTrackingID, theme } =
     useLoaderData<typeof loader>();
 
   const config = { isDevelopment, baseUrl, gaTrackingID };
 
   return (
-    <ThemeProvider>
+    <ThemeProvider initialTheme={theme}>
       <ToastProvider swipeDirection="right">
         <ConfigContextManager config={config}>
           <UserContextManager


### PR DESCRIPTION
# Description

Added an initial theme property to theme provider, which will set the theme initially to the user's preference and not "DARK".

### Checklist

- [X] discord username: `bumshaqalaqa#2973`
- [X] Closes #361 
- [X] PR must be created for an issue from issues under "In progress" column from [our project board](https://github.com/orgs/kamp-us/projects/2/views/1).
- [X] A descriptive and understandable title: The PR title should clearly describe the nature and purpose of the changes. The PR title should be the first thing displayed when the PR is opened. And it should follow the semantic commit rules, and should include the app/package/service name in the title. For example, a title like "docs(@kampus-apps/pano): Add README.md" can be used.
- [X] Related file selection: Only relevant files should be touched and no other files should be affected.
- [ ] I ran `npx turbo run` at the root of the repository, and build was successful.
- [ ] I installed the npm packages using `npm install --save-exact <package>` so my package is pinned to a specific npm version. Leave empty if no package was installed. Leave empty if no package was installed with this PR.

### How were these changes tested?

The problem only exists on published version at pano-dev.kamp.us. Yet in local builds, there was an initial render with "DARK" theme selected, which gets updated afterwards. I believe this re-render is not being triggered on pano-dev.kamp.us, since this PR solves our initial dark mode render problem, I believe it solves the refresh problem as well.
