### PR TITLE
fix(apps/pano): npm start does not run properly on windows computers

### DIFF
--- a/apps/pano/package.json
+++ b/apps/pano/package.json
@@ -9,7 +9,7 @@
     "dev:remix": "remix dev",
     "dev:prisma": "prisma migrate deploy && prisma generate && prisma db seed",
     "build": "remix build",
-    "start": "NODE_ENV=production remix-serve ./build",
+    "start": "cross-env NODE_ENV=production remix-serve ./build",
     "docker:start": "prisma migrate deploy && npm run start"
   },
   "prisma": {


### PR DESCRIPTION
# Description

npm start was not able to set NODE_ENV environment variable in windows systems, since the command was not right. Added cross-env prefix to make sure it runs on Windows computers

### Checklist

- [X] discord username: `bumshaqalaqa#2973`
- [X] Closes #370 
- [X] PR must be created for an issue from issues under "In progress" column from [our project board](https://github.com/orgs/kamp-us/projects/2/views/1).
- [X] A descriptive and understandable title: The PR title should clearly describe the nature and purpose of the changes. The PR title should be the first thing displayed when the PR is opened. And it should follow the semantic commit rules, and should include the app/package/service name in the title. For example, a title like "docs(@kampus-apps/pano): Add README.md" can be used.
- [X] Related file selection: Only relevant files should be touched and no other files should be affected.
- [ ] I ran `npx turbo run` at the root of the repository, and build was successful.
- [ ] I installed the npm packages using `npm install --save-exact <package>` so my package is pinned to a specific npm version. Leave empty if no package was installed. Leave empty if no package was installed with this PR.

### How were these changes tested?

Tested manually
