### PR TITLE
Create CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,1 @@
+*               @kamp-us/kampus-devs


### PR DESCRIPTION
add codeowners so we have auto-assignment via @kamp-us/kampus-devs 

I've set the repo up in a way that if a pull request is assigned to @kamp-us/kampus-devs then we use auto-assingment to a person from the team.