### PR TITLE
fix(apps/kampus):  change the source property of the first rule in next.config.mjs

### DIFF
--- a/apps/kampus/next.config.mjs
+++ b/apps/kampus/next.config.mjs
@@ -7,7 +7,7 @@ const config = {
         // if the host is `pano.*`,
         // this rewrite will be applied
         {
-          source: "/:path((?!_next/|_static/|[\\w-]+\\.\\w+).*)",
+          source: "/(?!_next/|_static/|[\\w-]+\\.\\w+).*",
           has: [
             {
               type: "host",
@@ -19,7 +19,7 @@ const config = {
         // if the host is `sozluk.*`,
         // this rewrite will be applied
         {
-          source: "/:path((?!_next/|_static/|[\\w-]+\\.\\w+).*)",
+          source: "/(?!_next/|_static/|[\\w-]+\\.\\w+).*",
           has: [
             {
               type: "host",


### PR DESCRIPTION
# Description
The source property of the first rule is using a regular expression that matches any path, except for paths that start with _next/, _static/, or a file extension.
```js
source: "/:path((?!_next/|_static/|[\\w-]+\\.\\w+).*)",
```
This means that the first rule will never be applied, because all paths will match the regular expression.

To fix this bug, we need to change the source property of the first rule to match only paths that start with /. For example, we could change it to the following:
```js
source: "/(?!_next/|_static/|[\\w-]+\\.\\w+).*",
```
