### PR TITLE
(apps/pano): Fix a bug that affects UX on first time login via OTP 

### DIFF
--- a/apps/pano/app/routes/__auth/login.tsx
+++ b/apps/pano/app/routes/__auth/login.tsx
@@ -13,6 +13,7 @@ import {
 import type { LoaderArgs, MetaFunction } from "@remix-run/node";
 import { json } from "@remix-run/node";
 import { useLoaderData, useSearchParams } from "@remix-run/react";
+import { useState } from "react";
 import { authenticator } from "~/authenticator.server";
 import { OAuthLoginForm } from "~/features/oauth/OAuthLoginForm";
 import { commitSession, getSession } from "~/session.server";
@@ -48,6 +49,11 @@ export const Login = () => {
   const [searchParams] = useSearchParams();
   const redirectTo = searchParams.get("redirectTo") ?? "/";
   const { hasSentEmail } = useLoaderData<typeof loader>();
+  const [code, setCode] = useState("");
+
+  function handleChange(e: React.FormEvent<HTMLInputElement>) {
+    setCode(e.currentTarget.value);
+  }
 
   return (
     <CenteredContainer>
@@ -57,7 +63,15 @@ export const Login = () => {
             {hasSentEmail ? (
               <>
                 <Label htmlFor="code">Giriş kodu</Label>
-                <Input id="code" name="code" type="text" placeholder="123456" size="2" />
+                <Input
+                  id="code"
+                  name="code"
+                  type="text"
+                  placeholder="123456"
+                  size="2"
+                  onChange={handleChange}
+                  value={code}
+                />
               </>
             ) : (
               <>


### PR DESCRIPTION
# Description

I have changed 'app/routes/__auth/login.tsx' file in the root of 'pano' app. 
I have added a useState and used it in one of the Input components _(one that holds otp code in it)_ in order to prevent value sharing with the other component.
Unfortunately I couldn't find any simpler solution without using a hook.

### Checklist

- [x] discord username: `xmsc`
- [x] Closes [#373](https://github.com/kamp-us/monorepo/issues/373)
- [x] PR must be created for an issue from issues under "In progress" column from [our project board](https://github.com/orgs/kamp-us/projects/2/views/1).
- [x] A descriptive and understandable title: The PR title should clearly describe the nature and purpose of the changes. The PR title should be the first thing displayed when the PR is opened. And it should follow the semantic commit rules, and should include the app/package/service name in the title. For example, a title like "docs(@kampus-apps/pano): Add README.md" can be used.
- [x] Related file selection: Only relevant files should be touched and no other files should be affected.
- [x] I ran `npx turbo run` at the root of the repository, and build was successful.
- [ ] I installed the npm packages using `npm install --save-exact <package>` so my package is pinned to a specific npm version. Leave empty if no package was installed. Leave empty if no package was installed with this PR.

### How were these changes tested?

I have tested it manually
