### PR TITLE
ci(repo): update turbo version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -31,7 +31,7 @@
         "tailwindcss-animate": "1.0.5",
         "ts-node": "10.9.1",
         "ts-node-dev": "2.0.0",
-        "turbo": "1.10.1",
+        "turbo": "1.10.3",
         "typescript": "5.0.4"
       }
     },
@@ -24495,30 +24495,92 @@
       }
     },
     "node_modules/turbo": {
-      "version": "1.10.1",
+      "version": "1.10.3",
+      "resolved": "https://registry.npmjs.org/turbo/-/turbo-1.10.3.tgz",
+      "integrity": "sha512-U4gKCWcKgLcCjQd4Pl8KJdfEKumpyWbzRu75A6FCj6Ctea1PIm58W6Ltw1QXKqHrl2pF9e1raAskf/h6dlrPCA==",
       "hasInstallScript": true,
-      "license": "MPL-2.0",
       "bin": {
         "turbo": "bin/turbo"
       },
       "optionalDependencies": {
-        "turbo-darwin-64": "1.10.1",
-        "turbo-darwin-arm64": "1.10.1",
-        "turbo-linux-64": "1.10.1",
-        "turbo-linux-arm64": "1.10.1",
-        "turbo-windows-64": "1.10.1",
-        "turbo-windows-arm64": "1.10.1"
+        "turbo-darwin-64": "1.10.3",
+        "turbo-darwin-arm64": "1.10.3",
+        "turbo-linux-64": "1.10.3",
+        "turbo-linux-arm64": "1.10.3",
+        "turbo-windows-64": "1.10.3",
+        "turbo-windows-arm64": "1.10.3"
       }
     },
-    "node_modules/turbo-darwin-arm64": {
-      "version": "1.10.1",
+    "node_modules/turbo-darwin-64": {
+      "version": "1.10.3",
+      "resolved": "https://registry.npmjs.org/turbo-darwin-64/-/turbo-darwin-64-1.10.3.tgz",
+      "integrity": "sha512-IIB9IomJGyD3EdpSscm7Ip1xVWtYb7D0x7oH3vad3gjFcjHJzDz9xZ/iw/qItFEW+wGFcLSRPd+1BNnuLM8AsA==",
       "cpu": [
-        "arm64"
+        "x64"
       ],
-      "license": "MPL-2.0",
       "optional": true,
       "os": [
         "darwin"
+      ]
+    },
+    "node_modules/turbo-darwin-arm64": {
+      "version": "1.10.3",
+      "resolved": "https://registry.npmjs.org/turbo-darwin-arm64/-/turbo-darwin-arm64-1.10.3.tgz",
+      "integrity": "sha512-SBNmOZU9YEB0eyNIxeeQ+Wi0Ufd+nprEVp41rgUSRXEIpXjsDjyBnKnF+sQQj3+FLb4yyi/yZQckB+55qXWEsw==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/turbo-linux-64": {
+      "version": "1.10.3",
+      "resolved": "https://registry.npmjs.org/turbo-linux-64/-/turbo-linux-64-1.10.3.tgz",
+      "integrity": "sha512-kvAisGKE7xHJdyMxZLvg53zvHxjqPK1UVj4757PQqtx9dnjYHSc8epmivE6niPgDHon5YqImzArCjVZJYpIGHQ==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/turbo-linux-arm64": {
+      "version": "1.10.3",
+      "resolved": "https://registry.npmjs.org/turbo-linux-arm64/-/turbo-linux-arm64-1.10.3.tgz",
+      "integrity": "sha512-Qgaqln0IYRgyL0SowJOi+PNxejv1I2xhzXOI+D+z4YHbgSx87ox1IsALYBlK8VRVYY8VCXl+PN12r1ioV09j7A==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/turbo-windows-64": {
+      "version": "1.10.3",
+      "resolved": "https://registry.npmjs.org/turbo-windows-64/-/turbo-windows-64-1.10.3.tgz",
+      "integrity": "sha512-rbH9wManURNN8mBnN/ZdkpUuTvyVVEMiUwFUX4GVE5qmV15iHtZfDLUSGGCP2UFBazHcpNHG1OJzgc55GFFrUw==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/turbo-windows-arm64": {
+      "version": "1.10.3",
+      "resolved": "https://registry.npmjs.org/turbo-windows-arm64/-/turbo-windows-arm64-1.10.3.tgz",
+      "integrity": "sha512-ThlkqxhcGZX39CaTjsHqJnqVe+WImjX13pmjnpChz6q5HHbeRxaJSFzgrHIOt0sUUVx90W/WrNRyoIt/aafniw==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
       ]
     },
     "node_modules/tweetnacl": {

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "tailwindcss-animate": "1.0.5",
     "ts-node": "10.9.1",
     "ts-node-dev": "2.0.0",
-    "turbo": "1.10.1",
+    "turbo": "1.10.3",
     "typescript": "5.0.4"
   },
   "packageManager": "npm@9.5.0",


### PR DESCRIPTION
updated the turbo version, we needed to do this anyway. but the weird thing is that it added turbo package resolutions back to the package-lock, which is why the builds were failing. interesting.